### PR TITLE
Implement transposition tables in Minimax

### DIFF
--- a/rust_chess/src/engine/minimax.rs
+++ b/rust_chess/src/engine/minimax.rs
@@ -23,23 +23,28 @@ pub struct TTEntry {
 }
 
 
+pub struct EngineOptions {
+    max_depth: usize,
+    quiescence_max_depth: usize,
+    use_transposition_tables: bool,
+}
+
 
 pub struct Minimax {
-    pub max_depth: usize,
-    pub quiescence_max_depth: usize,
-    pub selective_quiescence: bool,
+    pub engine_options: EngineOptions,
     pub tt: HashMap<u64, TTEntry>
 }
 
 impl Minimax {
-    pub fn new(max_depth: usize, quiescence_max_depth: usize, selective_quiescence: bool) -> Self {
-        Self { max_depth, quiescence_max_depth, selective_quiescence, tt: HashMap::new()}
+    pub fn new(max_depth: usize, quiescence_max_depth: usize, tt_tables: bool) -> Self {
+        let options = EngineOptions { max_depth: max_depth, quiescence_max_depth: quiescence_max_depth, use_transposition_tables: tt_tables};
+        Self { engine_options: options, tt: HashMap::new()}
     }
 
     pub fn find_best_move(&mut self, game: &mut Game, colour: Colour) -> Option<ChessMove> {
         self.tt.clear(); // clear TT for fresh search
 
-        let mut best_score = i32::MIN;
+        let mut best_score = -INF;
         let mut best_move: Option<ChessMove> = None;
         
         let mut move_scores = vec![];
@@ -49,7 +54,7 @@ impl Minimax {
         for mv in moves {
             game.make_move(&mv);
 
-            let score = -self.minimax(game, self.max_depth - 1, -INF, INF, colour.other());
+            let score = -self.minimax(game, self.engine_options.max_depth - 1, -INF, INF, colour.other());
 
             game.undo_last_move();
 
@@ -73,17 +78,18 @@ impl Minimax {
     fn minimax(&mut self, game: &mut Game, depth: usize, mut alpha: i32, mut beta: i32, colour: Colour) -> i32 {
         let hash = game.get_current_hash();
 
-        if let Some(entry) = self.tt.get(&hash) {
-            if entry.depth >= depth {
-                match entry.bound {
-                    Bound::Exact => return entry.value,
-                    Bound::Lower => alpha = alpha.max(entry.value),
-                    Bound::Upper => beta = beta.min(entry.value)
-                }
-                if alpha >= beta {
-                    return entry.value;
-                }
-            }
+        if self.engine_options.use_transposition_tables {
+            if let Some(entry) = self.tt.get(&hash) {
+                if entry.depth >= depth {
+                    match entry.bound {
+                        Bound::Exact => return entry.value,
+                        Bound::Lower => alpha = alpha.max(entry.value),
+                        Bound::Upper => beta = beta.min(entry.value)
+                    }
+                    if alpha >= beta {
+                        return entry.value;
+                    }
+            }   }
         }
 
         let moves = MoveGenerator::generate_legal_moves(game, colour);
@@ -93,15 +99,12 @@ impl Minimax {
         }
 
         if depth == 0 {
-            return if self.selective_quiescence {
-                self.quiescence(game, alpha, beta, self.quiescence_max_depth)
-            } else {
-                Evaluator::evaluate_game_result(game, None, depth, colour)
-            };
+            return self.quiescence(game, alpha, beta, self.engine_options.quiescence_max_depth);
         }
         
 
-        let mut best_score = i32::MIN;
+        let orig_alpha = alpha;
+        let mut best_score = -INF;
 
         for mv in &moves {
             game.make_move(&mv);
@@ -115,17 +118,19 @@ impl Minimax {
             }
         }
 
-        let bound = if best_score <= alpha {
-            Bound::Upper
-        }
-        else if  best_score >= beta {
-            Bound::Lower
-        }
-        else {
-            Bound::Exact
-        };
+        if self.engine_options.use_transposition_tables {
+            let bound = if best_score <= orig_alpha {
+                Bound::Upper
+            }
+            else if  best_score >= beta {
+                Bound::Lower
+            }
+            else {
+                Bound::Exact
+            };
 
-        self.tt.insert(hash, TTEntry { depth: depth, value: best_score, bound: bound });
+            self.tt.insert(hash, TTEntry { depth: depth, value: best_score, bound: bound });
+        }
         best_score
     }
 
@@ -134,28 +139,31 @@ impl Minimax {
     fn quiescence(&mut self, game: &mut Game, mut alpha: i32, mut beta: i32, max_depth: usize) -> i32 {
         let hash = game.get_current_hash();
 
-        if let Some(entry) = self.tt.get(&hash) {
-            if entry.depth >= max_depth {
-                match entry.bound {
-                    Bound::Exact => return entry.value,
-                    Bound::Lower => alpha = alpha.max(entry.value),
-                    Bound::Upper => beta = beta.min(entry.value),
-                }
-                if alpha >= beta {
-                    return entry.value;
+        if self.engine_options.use_transposition_tables {
+            if let Some(entry) = self.tt.get(&hash) {
+                if entry.depth >= max_depth {
+                    match entry.bound {
+                        Bound::Exact => return entry.value,
+                        Bound::Lower => alpha = alpha.max(entry.value),
+                        Bound::Upper => beta = beta.min(entry.value),
+                    }
+                    if alpha >= beta {
+                        return entry.value;
+                    }
                 }
             }
         }
+
         // Step 0: terminal positions
         let to_move = game.get_game_state().get_turn();
         let moves = MoveGenerator::generate_legal_moves(game, to_move);
 
         if let Some(result) = game.is_game_over_with_moves(&moves) {
-            return Evaluator::evaluate_game_result(game, Some(result), self.max_depth, to_move);
+            return Evaluator::evaluate_game_result(game, Some(result), self.engine_options.quiescence_max_depth, to_move);
         }
 
         // Step 1: stand pat evaluation
-        let stand_pat = Evaluator::evaluate_game_result(game, None, self.max_depth, to_move);
+        let stand_pat = Evaluator::evaluate_game_result(game, None, self.engine_options.quiescence_max_depth, to_move);
 
         if max_depth == 0 || stand_pat >= beta {
             return stand_pat;
@@ -186,14 +194,16 @@ impl Minimax {
             }
         }
 
-        let bound = if stand_pat <= alpha {
-            Bound::Upper
-        } else if stand_pat >= beta {
-            Bound::Lower
-        } else {
-            Bound::Exact
-        };
-        self.tt.insert(hash, TTEntry { depth: self.max_depth, value: stand_pat, bound: bound });
+        if self.engine_options.use_transposition_tables {
+            let bound = if alpha <= stand_pat {
+                Bound::Upper
+            } else if alpha >= beta {
+                Bound::Lower
+            } else {
+                Bound::Exact
+            };
+            self.tt.insert(hash, TTEntry { depth: max_depth, value: alpha, bound: bound });
+        }
 
 
         alpha

--- a/rust_chess/src/game_classes/game.rs
+++ b/rust_chess/src/game_classes/game.rs
@@ -141,6 +141,10 @@ impl Game {
         self.game_state.set_turn(colour);
     }
 
+    pub fn get_current_hash(&self) -> u64 {
+        self.hash
+    }
+
     pub fn get_player_pieces(&self, player: Colour) -> Vec<(Piece, Coords)> {
         self.board.get_player_pieces(player)
     }

--- a/rust_chess/tests/integration_tests.rs
+++ b/rust_chess/tests/integration_tests.rs
@@ -1,3 +1,5 @@
+use std::time::Instant;
+
 use rust_chess::PyMinimax;
 
 const startpos: &str = "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1";
@@ -29,5 +31,43 @@ fn test_minimax() {
 
 
     mini.go();
+}
+
+#[test]
+fn test_transposition_tables() {
+    let mut no_tt = PyMinimax::new(2, 4, false);
+    let mut tt = PyMinimax::new(2, 4, true);
+
+    let moves_str = "g1h3 d7d5 h1g1 c8h3 g2h3 e7e5 g1g4 h7h5 g4g1 b8c6 g1g3 g7g6 g3g1 d8f6 g1g3 f8c5 g3g2 f6f5 b1c3 g8f6 a1b1 e8c8 b1a1 e5e4 a1b1 c6b4 b1a1 e4e3 f2e3 d8e8";
+    let moves: Vec<String> = moves_str
+        .split_whitespace()
+        .map(|m| m.to_string())
+        .collect();
+
+
+    no_tt.set_position(startpos, moves.clone());
+    tt.set_position(startpos, moves.clone());
+
+
+    // Measure no_tt runtime
+    let start = Instant::now();
+    let no_tt_bestmove = no_tt.go();
+    let no_tt_duration = start.elapsed();
+
+    // Measure tt runtime
+    let start = Instant::now();
+    let tt_bestmove = tt.go();
+    let tt_duration = start.elapsed();
+
+    // Both should agree on evaluation and best move
+    assert_eq!(no_tt_bestmove, tt_bestmove, "Best moves differ between TT and no-TT");
+
+    // TT should be faster (give some leeway since timing is noisy)
+    assert!(
+        tt_duration < no_tt_duration,
+        "Expected TT search to be faster (no_tt: {:?}, tt: {:?})",
+        no_tt_duration,
+        tt_duration
+    );
 
 }


### PR DESCRIPTION
This PR changes the Minimax to use transposition tables to reduce the amount of recalculated positions.

This also introduces an engine options struct that should allow the engine to be modified.

Next steps are iterative deepening. 