### PR TITLE
Implement perft testing to benchmark pure move generation speed

### DIFF
--- a/rust_chess/src/lib.rs
+++ b/rust_chess/src/lib.rs
@@ -180,7 +180,7 @@ impl PyMinimax {
         }
     }
 
-    pub fn unmake_move(&mut self, _mv: &str) {
+    pub fn unmake_move(&mut self) {
         self.game.undo_last_move();
     }
 
@@ -200,7 +200,7 @@ impl PyMinimax {
         for mv in moves {
             self.make_move(&mv);
             nodes += self.perft(depth - 1);
-            self.unmake_move(&mv);
+            self.unmake_move();
         }
 
         nodes

--- a/rust_chess/src/lib.rs
+++ b/rust_chess/src/lib.rs
@@ -166,6 +166,45 @@ impl PyMinimax {
     pub fn get_minimax_tt_hits(&self) -> usize {
         self.inner.tt_hits
     }
+
+    pub fn generate_legal_moves(&mut self) -> Vec<String> {
+        let colour = self.game.get_game_state().get_turn();
+        let mut moves = Vec::new();
+        move_generator::MoveGenerator::generate_legal_moves_into(&mut self.game, colour, self.inner.engine_options.magic_bitboards, &mut moves);
+        moves.iter().map(|m| m.to_string()).collect()
+    }
+
+    pub fn make_move(&mut self, mv: &str) {
+        if let Some(chess_move) = MoveParser::parse_str(mv, &self.game) {
+            self.game.make_move(&chess_move);
+        }
+    }
+
+    pub fn unmake_move(&mut self, _mv: &str) {
+        self.game.undo_last_move();
+    }
+
+    pub fn perft(&mut self, depth: u32) -> u64 {
+        if depth == 0 {
+            return 1;
+        }
+
+        let moves = self.generate_legal_moves();
+
+        if depth == 1 {
+            return moves.len() as u64;
+        }
+
+        let mut nodes = 0;
+
+        for mv in moves {
+            self.make_move(&mv);
+            nodes += self.perft(depth - 1);
+            self.unmake_move(&mv);
+        }
+
+        nodes
+    }
 }
 
 

--- a/rust_chess/tests/perft.rs
+++ b/rust_chess/tests/perft.rs
@@ -1,5 +1,5 @@
 use std::time::Instant;
-use rust_chess::{enums::moves, PyMinimax};
+use rust_chess::PyMinimax;
 
 const STARTPOS: &str = "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1";
 

--- a/rust_chess/tests/perft.rs
+++ b/rust_chess/tests/perft.rs
@@ -3,60 +3,40 @@ use rust_chess::PyMinimax;
 
 const STARTPOS: &str = "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1";
 
-#[test]
-fn test_perft_startpos_depth1() {
+fn run_perft_startpos(depth: u32, expected_nodes: u64) {
     let mut engine = PyMinimax::new(0, 4, false, true); // Depth not used, disable TT for pure gen
     engine.set_position(STARTPOS, vec![]);
 
     let start = Instant::now();
-    let nodes = engine.perft(1);
+    let nodes = engine.perft(depth);
     let duration = start.elapsed();
 
     let nps = nodes as f64 / duration.as_secs_f64();
-    println!("Perft depth 1: {} nodes in {:.3?}, {:.2} nodes/sec", nodes, duration, nps);
-    assert_eq!(nodes, 20); // Standard perft value for startpos depth 1
+    println!(
+        "Perft depth {}: {} nodes in {:.3?}, {:.2} nodes/sec",
+        depth, nodes, duration, nps
+    );
+    assert_eq!(nodes, expected_nodes, "Perft node count mismatch at depth {}", depth);
+}
+
+#[test]
+fn test_perft_startpos_depth1() {
+    run_perft_startpos(1, 20); // Standard perft value for startpos depth 1
 }
 
 #[test]
 fn test_perft_startpos_depth2() {
-    let mut engine = PyMinimax::new(0, 4, false, true);
-    engine.set_position(STARTPOS, vec![]);
-
-    let start = Instant::now();
-    let nodes = engine.perft(2);
-    let duration = start.elapsed();
-
-    let nps = nodes as f64 / duration.as_secs_f64();
-    println!("Perft depth 2: {} nodes in {:.3?}, {:.2} nodes/sec", nodes, duration, nps);
-    assert_eq!(nodes, 400); // Standard perft value
+    run_perft_startpos(2, 400); // Standard perft value
 }
 
 #[test]
 fn test_perft_startpos_depth3() {
-    let mut engine = PyMinimax::new(0, 4, false, true);
-    engine.set_position(STARTPOS, vec![]);
-
-    let start = Instant::now();
-    let nodes = engine.perft(3);
-    let duration = start.elapsed();
-
-    let nps = nodes as f64 / duration.as_secs_f64();
-    println!("Perft depth 3: {} nodes in {:.3?}, {:.2} nodes/sec", nodes, duration, nps);
-    assert_eq!(nodes, 8902); // Standard perft value
+    run_perft_startpos(3, 8902); // Standard perft value
 }
 
 #[test]
 fn test_perft_startpos_depth4() {
-    let mut engine = PyMinimax::new(0, 4, false, true);
-    engine.set_position(STARTPOS, vec![]);
-
-    let start = Instant::now();
-    let nodes = engine.perft(4);
-    let duration = start.elapsed();
-
-    let nps = nodes as f64 / duration.as_secs_f64();
-    println!("Perft depth 4: {} nodes in {:.3?}, {:.2} nodes/sec", nodes, duration, nps);
-    assert_eq!(nodes, 197281); // Standard perft value
+    run_perft_startpos(4, 197281); // Standard perft value
 }
 
 #[test]

--- a/rust_chess/tests/perft.rs
+++ b/rust_chess/tests/perft.rs
@@ -1,0 +1,87 @@
+use std::time::Instant;
+use rust_chess::{enums::moves, PyMinimax};
+
+const STARTPOS: &str = "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1";
+
+#[test]
+fn test_perft_startpos_depth1() {
+    let mut engine = PyMinimax::new(0, 4, false, true); // Depth not used, disable TT for pure gen
+    engine.set_position(STARTPOS, vec![]);
+
+    let start = Instant::now();
+    let nodes = engine.perft(1);
+    let duration = start.elapsed();
+
+    let nps = nodes as f64 / duration.as_secs_f64();
+    println!("Perft depth 1: {} nodes in {:.3?}, {:.2} nodes/sec", nodes, duration, nps);
+    assert_eq!(nodes, 20); // Standard perft value for startpos depth 1
+}
+
+#[test]
+fn test_perft_startpos_depth2() {
+    let mut engine = PyMinimax::new(0, 4, false, true);
+    engine.set_position(STARTPOS, vec![]);
+
+    let start = Instant::now();
+    let nodes = engine.perft(2);
+    let duration = start.elapsed();
+
+    let nps = nodes as f64 / duration.as_secs_f64();
+    println!("Perft depth 2: {} nodes in {:.3?}, {:.2} nodes/sec", nodes, duration, nps);
+    assert_eq!(nodes, 400); // Standard perft value
+}
+
+#[test]
+fn test_perft_startpos_depth3() {
+    let mut engine = PyMinimax::new(0, 4, false, true);
+    engine.set_position(STARTPOS, vec![]);
+
+    let start = Instant::now();
+    let nodes = engine.perft(3);
+    let duration = start.elapsed();
+
+    let nps = nodes as f64 / duration.as_secs_f64();
+    println!("Perft depth 3: {} nodes in {:.3?}, {:.2} nodes/sec", nodes, duration, nps);
+    assert_eq!(nodes, 8902); // Standard perft value
+}
+
+#[test]
+fn test_perft_startpos_depth4() {
+    let mut engine = PyMinimax::new(0, 4, false, true);
+    engine.set_position(STARTPOS, vec![]);
+
+    let start = Instant::now();
+    let nodes = engine.perft(4);
+    let duration = start.elapsed();
+
+    let nps = nodes as f64 / duration.as_secs_f64();
+    println!("Perft depth 4: {} nodes in {:.3?}, {:.2} nodes/sec", nodes, duration, nps);
+    assert_eq!(nodes, 197281); // Standard perft value
+}
+
+#[test]
+fn test_perft_magic_vs_no_magic() {
+    let mut no_magic = PyMinimax::new(0, 4, false, false);
+    let mut magic = PyMinimax::new(0, 4, false, true);
+
+    no_magic.set_position(STARTPOS, vec![]);
+    magic.set_position(STARTPOS, vec![]);
+
+    let start = Instant::now();
+    let nodes_no_magic = no_magic.perft(4);
+    let duration_no_magic = start.elapsed();
+
+    let start = Instant::now();
+    let nodes_magic = magic.perft(4);
+    let duration_magic = start.elapsed();
+
+    let nps_no_magic = nodes_no_magic as f64 / duration_no_magic.as_secs_f64();
+    let nps_magic = nodes_magic as f64 / duration_magic.as_secs_f64();
+
+    println!("No Magic: {} nodes in {:.3?}, {:.2} nps", nodes_no_magic, duration_no_magic, nps_no_magic);
+    println!("Magic: {} nodes in {:.3?}, {:.2} nps", nodes_magic, duration_magic, nps_magic);
+
+    assert_eq!(nodes_no_magic, nodes_magic); // Should be same node count
+    // Magic should be faster
+    assert!(nps_magic > nps_no_magic, "Magic bitboards should be faster for move generation");
+}

--- a/rust_chess/tests/perft.rs
+++ b/rust_chess/tests/perft.rs
@@ -62,6 +62,5 @@ fn test_perft_magic_vs_no_magic() {
     println!("Magic: {} nodes in {:.3?}, {:.2} nps", nodes_magic, duration_magic, nps_magic);
 
     assert_eq!(nodes_no_magic, nodes_magic); // Should be same node count
-    // Magic should be faster
-    assert!(nps_magic > nps_no_magic, "Magic bitboards should be faster for move generation");
+    // Performance comparison is printed for manual inspection; timing-based assertions are unreliable in CI.
 }


### PR DESCRIPTION
Adds perft test for move generation.

Utilizes bulk counting for speed up. 

To increase perft speed, see the psuedo-legal moves section here:
https://www.chessprogramming.org/Perft

As of right now, move rays generates ~35000 nps while magic bitboards generates ~ 150000 nps.