### PR TITLE
Modify move generation to use single move buffer

### DIFF
--- a/rust_chess/src/engine/minimax.rs
+++ b/rust_chess/src/engine/minimax.rs
@@ -78,18 +78,19 @@ impl Minimax {
         out
     }
 
-    pub fn find_best_move(&mut self, game: &mut Game, colour: Colour) -> Option<ChessMove> {
+    pub fn find_best_move(&mut self, game: &mut Game, colour: Colour, return_scores: bool) -> (Option<ChessMove>, Option<Vec<(ChessMove, i32)>>) {
         self.move_buffer.clear();
-
         Self::generate_and_order_moves(self, game, colour, 0);
 
         let mut best_move: Option<ChessMove> = None;
         let mut best_score: i32 = -INF;
+        let mut final_move_scores: Vec<(ChessMove, i32)> = Vec::new();  // To store scores at max depth
 
         // Loop for iterative deepening
         for depth in 1..=self.engine_options.max_depth {
             let mut current_best: Option<ChessMove> = None;
             let mut current_best_score = -INF;
+            let mut current_move_scores: Vec<(ChessMove, i32)> = Vec::new();  // Collect scores for this depth
 
             // PV move promotion
             if let Some(prev_best) = &best_move {
@@ -100,13 +101,13 @@ impl Minimax {
             }
 
             for i in (0..self.move_buffer.len()).rev() {
-                let mv = self.move_buffer[i]; 
+                let mv = self.move_buffer[i];
 
                 game.make_move(&mv);
-
                 let score = -self.minimax(game, depth - 1, -INF, INF, colour.other(), 1);
-
                 game.undo_last_move();
+
+                current_move_scores.push((mv, score));
 
                 if score > current_best_score {
                     current_best_score = score;
@@ -118,37 +119,28 @@ impl Minimax {
                 best_move = Some(mv);
                 best_score = current_best_score;
             }
+
+            // At max depth, store and print the sorted scores
+            if depth == self.engine_options.max_depth {
+                final_move_scores = current_move_scores;
+                final_move_scores.sort_by(|a, b| b.1.cmp(&a.1));  // Sort descending by score
+                println!("Moves with scores at depth {}:", depth);
+                for (mv, score) in &final_move_scores {
+                    println!("{}: {}", mv, score);
+                }
+            }
         }
 
-        best_move
-    }
-    // Does not use iterative deepening
-    // Should be used for move ordering/evaluation and sanity checks. Not for actual move selection.
-    pub fn find_sorted_moves(&mut self, game: &mut Game, colour: Colour) -> Vec<(ChessMove, i32)> {
-        self.move_buffer.clear();
-
-        Self::generate_and_order_moves(self, game, colour, 0);
-
-        let mut move_scores: Vec<(ChessMove, i32)> = Vec::new();
-
-        // Use the configured max depth
-        let depth = self.engine_options.max_depth;
-
-        while let Some(mv) = self.move_buffer.pop()  {
-            game.make_move(&mv);
-
-            // Recurse with minimax at ply 1
-            let score = -self.minimax(game, depth - 1, -INF, INF, colour.other(), 1);
-
-            game.undo_last_move();
-
-            move_scores.push((mv, score));
+        if return_scores {
+            // At max depth, return final_move_scores instead of printing
+            (best_move, Some(final_move_scores))
+        } else {
+            println!("Moves with scores at depth {}:", self.engine_options.max_depth);
+            for (mv, score) in &final_move_scores {
+                println!("{}: {}", mv, score);
+            }
+            (best_move, None)
         }
-
-        // Sort descending by score
-        move_scores.sort_by(|a, b| b.1.cmp(&a.1));
-
-        move_scores
     }
 
     // Helper: Probe the TT for a usable entry
@@ -387,7 +379,7 @@ mod tests {
         let mut game = starting_game();
         let mut engine = Minimax::new(1, 1, false, false);
 
-        let best_move = engine.find_best_move(&mut game, Colour::White);
+        let (best_move, _) = engine.find_best_move(&mut game, Colour::White, false);
 
         assert!(best_move.is_some(), "Best move should not be None");
 
@@ -467,7 +459,6 @@ mod tests {
         assert!(eval < 0, "Evaluation should indicate checkmate loss for White");
     }
 
-
     #[test]
     fn test_black_gets_checkmated() {
         let mut game = Game::new();
@@ -499,7 +490,8 @@ mod tests {
 
 
         let to_move = game.get_game_state().get_turn();
-        let moves = engine.find_sorted_moves(&mut game, to_move);
+        let (_, scores_opt) = engine.find_best_move(&mut game, to_move, true);
+        let moves = scores_opt.unwrap();
 
         // Ensure there is at least one move
         assert!(!moves.is_empty(), "There should be at least one legal move for White");
@@ -520,7 +512,6 @@ mod tests {
         for w in moves.windows(2) {
             assert!(w[0].1 >= w[1].1, "Moves are not sorted by descending evaluation");
         }
-
     }
 
     #[test]
@@ -559,9 +550,9 @@ mod tests {
         game.make_move(&d2_d4);
         game.make_move(&g7_g5);
 
-
         let to_move = game.get_game_state().get_turn();
-        let moves = engine.find_sorted_moves(&mut game, to_move);
+        let (_, scores_opt) = engine.find_best_move(&mut game, to_move, true);
+        let moves = scores_opt.unwrap();
 
         // Ensure there is at least one move
         assert!(!moves.is_empty(), "There should be at least one legal move for White");
@@ -582,7 +573,6 @@ mod tests {
         for w in moves.windows(2) {
             assert!(w[0].1 >= w[1].1, "Moves are not sorted by descending evaluation");
         }
-
     }
 
     #[test]

--- a/rust_chess/src/engine/minimax.rs
+++ b/rust_chess/src/engine/minimax.rs
@@ -104,10 +104,11 @@ impl Minimax {
                 }
             }
 
-            for mv in self.move_buffer.clone() {
+            for i in (0..self.move_buffer.len()).rev() {
+                let mv = self.move_buffer[i]; 
+
                 game.make_move(&mv);
 
-                // recurse: pass ply = 1 for child
                 let score = -self.minimax(game, depth - 1, -INF, INF, colour.other(), 1);
 
                 game.undo_last_move();

--- a/rust_chess/src/engine/minimax.rs
+++ b/rust_chess/src/engine/minimax.rs
@@ -78,18 +78,19 @@ impl Minimax {
         out
     }
 
-    pub fn find_best_move(&mut self, game: &mut Game, colour: Colour) -> Option<ChessMove> {
+    pub fn find_best_move(&mut self, game: &mut Game, colour: Colour, return_scores: bool) -> (Option<ChessMove>, Option<Vec<(ChessMove, i32)>>) {
         self.move_buffer.clear();
-
         Self::generate_and_order_moves(self, game, colour, 0);
 
         let mut best_move: Option<ChessMove> = None;
         let mut best_score: i32 = -INF;
+        let mut final_move_scores: Vec<(ChessMove, i32)> = Vec::new();  // To store scores at max depth
 
         // Loop for iterative deepening
         for depth in 1..=self.engine_options.max_depth {
             let mut current_best: Option<ChessMove> = None;
             let mut current_best_score = -INF;
+            let mut current_move_scores: Vec<(ChessMove, i32)> = Vec::new();  // Collect scores for this depth
 
             // PV move promotion
             if let Some(prev_best) = &best_move {
@@ -100,13 +101,13 @@ impl Minimax {
             }
 
             for i in (0..self.move_buffer.len()).rev() {
-                let mv = self.move_buffer[i]; 
+                let mv = self.move_buffer[i];
 
                 game.make_move(&mv);
-
                 let score = -self.minimax(game, depth - 1, -INF, INF, colour.other(), 1);
-
                 game.undo_last_move();
+
+                current_move_scores.push((mv, score));
 
                 if score > current_best_score {
                     current_best_score = score;
@@ -118,37 +119,28 @@ impl Minimax {
                 best_move = Some(mv);
                 best_score = current_best_score;
             }
+
+            // At max depth, store and print the sorted scores
+            if depth == self.engine_options.max_depth {
+                final_move_scores = current_move_scores;
+                final_move_scores.sort_by(|a, b| b.1.cmp(&a.1));  // Sort descending by score
+                println!("Moves with scores at depth {}:", depth);
+                for (mv, score) in &final_move_scores {
+                    println!("{}: {}", mv, score);
+                }
+            }
         }
 
-        best_move
-    }
-    // Does not use iterative deepening
-    // Should be used for move ordering/evaluation and sanity checks. Not for actual move selection.
-    pub fn find_sorted_moves(&mut self, game: &mut Game, colour: Colour) -> Vec<(ChessMove, i32)> {
-        self.move_buffer.clear();
-
-        Self::generate_and_order_moves(self, game, colour, 0);
-
-        let mut move_scores: Vec<(ChessMove, i32)> = Vec::new();
-
-        // Use the configured max depth
-        let depth = self.engine_options.max_depth;
-
-        while let Some(mv) = self.move_buffer.pop()  {
-            game.make_move(&mv);
-
-            // Recurse with minimax at ply 1
-            let score = -self.minimax(game, depth - 1, -INF, INF, colour.other(), 1);
-
-            game.undo_last_move();
-
-            move_scores.push((mv, score));
+        if return_scores {
+            // At max depth, return final_move_scores instead of printing
+            (best_move, Some(final_move_scores))
+        } else {
+            println!("Moves with scores at depth {}:", self.engine_options.max_depth);
+            for (mv, score) in &final_move_scores {
+                println!("{}: {}", mv, score);
+            }
+            (best_move, None)
         }
-
-        // Sort descending by score
-        move_scores.sort_by(|a, b| b.1.cmp(&a.1));
-
-        move_scores
     }
 
     // Helper: Probe the TT for a usable entry
@@ -194,7 +186,17 @@ impl Minimax {
         }
     }
 
-    // minimax now takes an explicit depth_level parameter so each level uses its own buffers
+    // Helper to generate and order moves starting from a given index in move_buffer
+    fn generate_and_order_moves(&mut self, game: &mut Game, colour: Colour, start_index: usize) {
+        MoveGenerator::generate_legal_moves_into(
+            game,
+            colour,
+            self.engine_options.magic_bitboards,
+            &mut self.move_buffer,
+        );
+        order_moves(&mut self.move_buffer[start_index..], game);
+    }
+
     fn minimax(&mut self, game: &mut Game, depth: usize, mut alpha: i32, mut beta: i32, colour: Colour, depth_level: usize) -> i32 {
         self.nodes += 1;
         let hash = game.get_current_hash();
@@ -224,7 +226,6 @@ impl Minimax {
             let mv = self.move_buffer.pop().unwrap();
             game.make_move(&mv);
 
-            // recursive call will generate into move_buffers[ply + 1]
             let score = -self.minimax(game, depth - 1, -beta, -alpha, colour.other(), depth_level + 1);
 
             game.undo_last_move();
@@ -319,17 +320,6 @@ impl Minimax {
 
         best_score
     }
-
-    // Helper to generate and order moves starting from a given index in move_buffer
-    fn generate_and_order_moves(&mut self, game: &mut Game, colour: Colour, start_index: usize) {
-        MoveGenerator::generate_legal_moves_into(
-            game,
-            colour,
-            self.engine_options.magic_bitboards,
-            &mut self.move_buffer,
-        );
-        order_moves(&mut self.move_buffer[start_index..], game);
-    }
 }
 
 #[cfg(test)]
@@ -387,7 +377,7 @@ mod tests {
         let mut game = starting_game();
         let mut engine = Minimax::new(1, 1, false, false);
 
-        let best_move = engine.find_best_move(&mut game, Colour::White);
+        let (best_move, _) = engine.find_best_move(&mut game, Colour::White, false);
 
         assert!(best_move.is_some(), "Best move should not be None");
 
@@ -467,7 +457,6 @@ mod tests {
         assert!(eval < 0, "Evaluation should indicate checkmate loss for White");
     }
 
-
     #[test]
     fn test_black_gets_checkmated() {
         let mut game = Game::new();
@@ -499,7 +488,8 @@ mod tests {
 
 
         let to_move = game.get_game_state().get_turn();
-        let moves = engine.find_sorted_moves(&mut game, to_move);
+        let (_, scores_opt) = engine.find_best_move(&mut game, to_move, true);
+        let moves = scores_opt.unwrap();
 
         // Ensure there is at least one move
         assert!(!moves.is_empty(), "There should be at least one legal move for White");
@@ -520,7 +510,6 @@ mod tests {
         for w in moves.windows(2) {
             assert!(w[0].1 >= w[1].1, "Moves are not sorted by descending evaluation");
         }
-
     }
 
     #[test]
@@ -559,9 +548,9 @@ mod tests {
         game.make_move(&d2_d4);
         game.make_move(&g7_g5);
 
-
         let to_move = game.get_game_state().get_turn();
-        let moves = engine.find_sorted_moves(&mut game, to_move);
+        let (_, scores_opt) = engine.find_best_move(&mut game, to_move, true);
+        let moves = scores_opt.unwrap();
 
         // Ensure there is at least one move
         assert!(!moves.is_empty(), "There should be at least one legal move for White");
@@ -582,7 +571,6 @@ mod tests {
         for w in moves.windows(2) {
             assert!(w[0].1 >= w[1].1, "Moves are not sorted by descending evaluation");
         }
-
     }
 
     #[test]

--- a/rust_chess/src/engine/minimax.rs
+++ b/rust_chess/src/engine/minimax.rs
@@ -8,6 +8,7 @@ use crate::move_ordering::order_moves;
 use crate::engine::evaluator::Evaluator;
 
 pub const INF: i32 = 30_000;
+pub const MAX_MOVES: usize = 2048;
 
 #[derive(Clone, Copy)]
 pub enum Bound {
@@ -39,10 +40,7 @@ pub struct Minimax {
     pub nodes: usize,
     pub tt_hits: usize,
 
-    // move buffers: one Vec<ChessMove> per ply (0..=max_depth)
-    pub move_buffers: Vec<Vec<ChessMove>>,
-    // tactical buffers for quiescence (captures/promotions) per ply
-    pub tactical_buffers: Vec<Vec<ChessMove>>,
+    pub move_buffer: Vec<ChessMove>,
 }
 
 impl Minimax {
@@ -57,26 +55,13 @@ impl Minimax {
             magic_bitboards: magic_bitboard,
         };
 
-        // preallocate per-ply buffers: need max_depth + 2 to be safe (root + depths)
-        let buffer_count = max_depth + 2;
-        let mut move_buffers = Vec::with_capacity(buffer_count);
-        for _ in 0..buffer_count {
-            move_buffers.push(Vec::with_capacity(256));     // ~MAX_MOVES
-        }
-
-        let tact_buffer_count = quiescence_max_depth + 2;
-        let mut tactical_buffers = Vec::with_capacity(tact_buffer_count);
-        for _ in 0..tact_buffer_count {
-            tactical_buffers.push(Vec::with_capacity(64));  // fewer tactical moves typically
-        }
-
+        let move_buffer = Vec::with_capacity(MAX_MOVES);
         Self {
             engine_options: options,
             tt: HashMap::new(),
             nodes: 0,
             tt_hits: 0,
-            move_buffers,
-            tactical_buffers,
+            move_buffer,
         }
     }
 
@@ -84,17 +69,14 @@ impl Minimax {
         game.make_move(mv);
         let to_move = game.get_game_state().get_turn();
 
-        // use ply 0 buffer for this temporary generation
-        let ply = 0;
-        self.move_buffers[ply].clear();
         MoveGenerator::generate_legal_moves_into(
             game,
             to_move,
             self.engine_options.magic_bitboards,
-            &mut self.move_buffers[ply],
+            &mut self.move_buffer,
         );
 
-        let game_result = game.is_game_over_with_moves(&self.move_buffers[ply], self.engine_options.magic_bitboards);
+        let game_result = game.is_game_over_with_moves(&self.move_buffer, self.engine_options.magic_bitboards);
         let out = Evaluator::evaluate_game_result(game, game_result, 0, to_move);
 
         game.undo_last_move();
@@ -105,33 +87,29 @@ impl Minimax {
         let mut best_move: Option<ChessMove> = None;
         let mut best_score: i32 = -INF;
 
+        self.move_buffer.clear();
+        MoveGenerator::generate_legal_moves_into(
+            game,
+            colour,
+            self.engine_options.magic_bitboards,
+            &mut self.move_buffer,
+        );
+        order_moves(&mut self.move_buffer[..], game);
+
         for depth in 1..=self.engine_options.max_depth {
             let mut current_best: Option<ChessMove> = None;
             let mut current_best_score = -INF;
 
-            // root is ply 0
-            let root_ply = 0;
-            self.move_buffers[root_ply].clear();
-            MoveGenerator::generate_legal_moves_into(
-                game,
-                colour,
-                self.engine_options.magic_bitboards,
-                &mut self.move_buffers[root_ply],
-            );
-            order_moves(&mut self.move_buffers[root_ply], game);
 
             // PV move promotion
             if let Some(prev_best) = &best_move {
-                if let Some(idx) = self.move_buffers[root_ply].iter().position(|m| m == prev_best) {
-                    let mv = self.move_buffers[root_ply].remove(idx);
-                    self.move_buffers[root_ply].insert(0, mv);
+                if let Some(idx) = self.move_buffer.iter().position(|m| m == prev_best) {
+                    let mv = self.move_buffer.remove(idx);
+                    self.move_buffer.push(mv);
                 }
             }
 
-            let len = self.move_buffers[root_ply].len();
-            for i in 0..len {
-                // clone the move out (requires ChessMove: Clone)
-                let mv = self.move_buffers[root_ply][i].clone();
+            for mv in self.move_buffer.clone() {
                 game.make_move(&mv);
 
                 // recurse: pass ply = 1 for child
@@ -159,20 +137,16 @@ impl Minimax {
         // Use the configured max depth
         let depth = self.engine_options.max_depth;
 
-        // root is ply 0
-        let root_ply = 0;
-        self.move_buffers[root_ply].clear();
+        self.move_buffer.clear();
         MoveGenerator::generate_legal_moves_into(
             game,
             colour,
             self.engine_options.magic_bitboards,
-            &mut self.move_buffers[root_ply],
+            &mut self.move_buffer,
         );
-        order_moves(&mut self.move_buffers[root_ply], game);
+        order_moves(&mut self.move_buffer, game);
 
-        let len = self.move_buffers[root_ply].len();
-        for i in 0..len {
-            let mv = self.move_buffers[root_ply][i].clone();
+        while let Some(mv) = self.move_buffer.pop()  {
             game.make_move(&mv);
 
             // Recurse with minimax at ply 1
@@ -210,30 +184,32 @@ impl Minimax {
             }
         }
 
+        let move_start_index = self.move_buffer.len();
+
         // generate moves into buffer for this ply
-        self.move_buffers[ply].clear();
         MoveGenerator::generate_legal_moves_into(
             game,
             colour,
             self.engine_options.magic_bitboards,
-            &mut self.move_buffers[ply],
+            &mut self.move_buffer,
         );
-        order_moves(&mut self.move_buffers[ply], game);
+        order_moves(&mut self.move_buffer[move_start_index..], game);
 
-        if let Some(result) = game.is_game_over_with_moves(&self.move_buffers[ply], self.engine_options.magic_bitboards) {
+        if let Some(result) = game.is_game_over_with_moves(&self.move_buffer[move_start_index..], self.engine_options.magic_bitboards) {
+            self.move_buffer.truncate(move_start_index);
             return Evaluator::evaluate_game_result(game, Some(result), ply, colour);
         }
 
         if depth == 0 {
+            self.move_buffer.truncate(move_start_index);
             return self.quiescence(game, alpha, beta, self.engine_options.quiescence_max_depth, 0);
         }
 
         let orig_alpha = alpha;
         let mut best_score = -INF;
 
-        let len = self.move_buffers[ply].len();
-        for i in 0..len {
-            let mv = self.move_buffers[ply][i].clone();
+        while self.move_buffer.len() > move_start_index {
+            let mv = self.move_buffer.pop().unwrap();
             game.make_move(&mv);
 
             // recursive call will generate into move_buffers[ply + 1]
@@ -282,6 +258,7 @@ impl Minimax {
             }
         }
 
+        self.move_buffer.truncate(move_start_index);
         best_score
     }
 
@@ -316,7 +293,6 @@ impl Minimax {
         let to_move = game.get_game_state().get_turn();
         let escape_check = game.is_player_in_check(to_move, self.engine_options.magic_bitboards);
 
-
         // stand pat
         let stand_pat = Evaluator::evaluate_game_result(game, None, ply, to_move);
         if max_depth == 0 || (!escape_check && stand_pat >= beta) {
@@ -326,26 +302,24 @@ impl Minimax {
             alpha = stand_pat;
         }
 
+        let move_start_index = self.move_buffer.len();
         // generate only tactical moves into the tactical buffer for this ply
-        self.tactical_buffers[ply].clear();
         MoveGenerator::generate_legal_moves_into(
             game,
             to_move,
             self.engine_options.magic_bitboards,
-            &mut self.tactical_buffers[ply],
+            &mut self.move_buffer,
         );
-        order_moves(&mut self.tactical_buffers[ply], game);
-
-        if let Some(result) = game.is_game_over_with_moves(&self.tactical_buffers[ply], self.engine_options.magic_bitboards) {
+        order_moves(&mut self.move_buffer[move_start_index..], game);
+        if let Some(result) = game.is_game_over_with_moves(&self.move_buffer[move_start_index..], self.engine_options.magic_bitboards) {
+            self.move_buffer.truncate(move_start_index);
             return Evaluator::evaluate_game_result(game, Some(result), ply, to_move);
         }
 
         let mut best_score = if !escape_check {stand_pat} else {-INF};
-        let len = self.tactical_buffers[ply].len();
 
-
-        for i in 0..len {
-            let mv = self.tactical_buffers[ply][i].clone();
+        while self.move_buffer.len() > move_start_index {
+            let mv = self.move_buffer.pop().unwrap();
             if !escape_check && !MoveGenerator::is_tactical_move(game, &mv, self.engine_options.magic_bitboards) {
                 continue
             }
@@ -354,6 +328,7 @@ impl Minimax {
             game.undo_last_move();
 
             if score >= beta {
+                self.move_buffer.truncate(move_start_index);
                 return score;
             }
             if score > best_score {
@@ -392,6 +367,8 @@ impl Minimax {
 
 #[cfg(test)]
 mod tests {
+    use std::vec;
+
     use super::*;
     use crate::coords::Coords;
     use crate::enums::moves::NormalMove;
@@ -409,16 +386,15 @@ mod tests {
         let mut engine = Minimax::new(3, 6, true, true);
 
         // Generate legal moves at the root
-        engine.move_buffers[0].clear();
         MoveGenerator::generate_legal_moves_into(
             &mut game,
             Colour::White,
             false,
-            &mut engine.move_buffers[0],
+            &mut engine.move_buffer,
         );
 
         // Pick the first move to evaluate
-        let mv = engine.move_buffers[0][0].clone();
+        let mv = engine.move_buffer[0].clone();
         let eval = engine.evaluate_move(&mut game, &mv);
 
         // Evaluation should be within reasonable bounds for starting position
@@ -450,14 +426,14 @@ mod tests {
 
         // Make sure the move is legal
         let mv = best_move.unwrap();
-        engine.move_buffers[0].clear();
+        let mut legal_moves = vec![];
         MoveGenerator::generate_legal_moves_into(
             &mut game,
             Colour::White,
             false,
-            &mut engine.move_buffers[0],
+            &mut legal_moves,
         );
-        assert!(engine.move_buffers[0].contains(&mv), "Best move is not legal");
+        assert!(legal_moves.contains(&mv), "Best move is not legal");
     }
 
     #[test]
@@ -466,14 +442,14 @@ mod tests {
         let mut engine = Minimax::new(1, 1, false, false);
 
         // Pick one move from root and evaluate using minimax
-        engine.move_buffers[0].clear();
+        engine.move_buffer.clear();
         MoveGenerator::generate_legal_moves_into(
             &mut game,
             Colour::White,
             false,
-            &mut engine.move_buffers[0],
+            &mut engine.move_buffer,
         );
-        let mv = engine.move_buffers[0][0].clone();
+        let mv = engine.move_buffer[0].clone();
 
         game.make_move(&mv);
         let score = -engine.minimax(&mut game, 0, -INF, INF, Colour::Black, 1);

--- a/rust_chess/src/engine/minimax.rs
+++ b/rust_chess/src/engine/minimax.rs
@@ -1,4 +1,3 @@
-use std::any::Any;
 use std::collections::HashMap;
 
 use crate::game_classes::game::Game;
@@ -69,14 +68,10 @@ impl Minimax {
         game.make_move(mv);
         let to_move = game.get_game_state().get_turn();
 
-        MoveGenerator::generate_legal_moves_into(
-            game,
-            to_move,
-            self.engine_options.magic_bitboards,
-            &mut self.move_buffer,
-        );
+        let move_start_index = self.move_buffer.len();
+        Self::generate_and_order_moves(self, game, to_move, move_start_index);
 
-        let game_result = game.is_game_over_with_moves(&self.move_buffer, self.engine_options.magic_bitboards);
+        let game_result = game.is_game_over_with_moves(&self.move_buffer[move_start_index..], self.engine_options.magic_bitboards);
         let out = Evaluator::evaluate_game_result(game, game_result, 0, to_move);
 
         game.undo_last_move();
@@ -84,22 +79,22 @@ impl Minimax {
     }
 
     pub fn find_best_move(&mut self, game: &mut Game, colour: Colour) -> Option<ChessMove> {
-        let mut best_move: Option<ChessMove> = None;
-        let mut best_score: i32 = -INF;
-
         self.move_buffer.clear();
 
         Self::generate_and_order_moves(self, game, colour, 0);
 
+        let mut best_move: Option<ChessMove> = None;
+        let mut best_score: i32 = -INF;
+
+        // Loop for iterative deepening
         for depth in 1..=self.engine_options.max_depth {
             let mut current_best: Option<ChessMove> = None;
             let mut current_best_score = -INF;
 
-
             // PV move promotion
             if let Some(prev_best) = &best_move {
                 if let Some(idx) = self.move_buffer.iter().position(|m| m == prev_best) {
-                    let mv = self.move_buffer.remove(idx);
+                    let mv = self.move_buffer.swap_remove(idx);
                     self.move_buffer.push(mv);
                 }
             }
@@ -127,14 +122,17 @@ impl Minimax {
 
         best_move
     }
+    // Does not use iterative deepening
+    // Should be used for move ordering/evaluation and sanity checks. Not for actual move selection.
     pub fn find_sorted_moves(&mut self, game: &mut Game, colour: Colour) -> Vec<(ChessMove, i32)> {
+        self.move_buffer.clear();
+
+        Self::generate_and_order_moves(self, game, colour, 0);
+
         let mut move_scores: Vec<(ChessMove, i32)> = Vec::new();
 
         // Use the configured max depth
         let depth = self.engine_options.max_depth;
-
-        self.move_buffer.clear();
-        Self::generate_and_order_moves(self, game, colour, 0);
 
         while let Some(mv) = self.move_buffer.pop()  {
             game.make_move(&mv);
@@ -153,34 +151,65 @@ impl Minimax {
         move_scores
     }
 
-    // minimax now takes an explicit ply parameter so each level uses its own buffers
-    fn minimax(&mut self, game: &mut Game, depth: usize, mut alpha: i32, mut beta: i32, colour: Colour, ply: usize) -> i32 {
-        self.nodes += 1;
-        let hash = game.get_current_hash();
-
-        if self.engine_options.use_transposition_tables {
-            if let Some(entry) = self.tt.get(&hash) {
-                if !entry.is_quiescence && entry.depth >= depth {
-                    self.tt_hits += 1;
-                    match entry.bound {
-                        Bound::Exact => return entry.value,
-                        Bound::Lower => alpha = alpha.max(entry.value),
-                        Bound::Upper => beta = beta.min(entry.value),
-                    }
-                    if alpha >= beta {
-                        return entry.value;
-                    }
+    // Helper: Probe the TT for a usable entry
+    fn tt_lookup(&mut self, hash: u64, depth: usize, is_quiescence: bool, alpha: &mut i32, beta: &mut i32) -> Option<i32> {
+        if !self.engine_options.use_transposition_tables {
+            return None;
+        }
+        if let Some(entry) = self.tt.get(&hash) {
+            if (!entry.is_quiescence && !is_quiescence && entry.depth >= depth)
+                || (entry.is_quiescence && is_quiescence && entry.depth >= depth) {
+                self.tt_hits += 1;
+                match entry.bound {
+                    Bound::Exact => return Some(entry.value),
+                    Bound::Lower => *alpha = (*alpha).max(entry.value),
+                    Bound::Upper => *beta = (*beta).min(entry.value),
+                }
+                if *alpha >= *beta {
+                    return Some(entry.value);
                 }
             }
         }
+        None
+    }
+
+    // Helper: Store a new entry in the TT with replacement logic
+    fn tt_store(&mut self, hash: u64, depth: usize, value: i32, bound: Bound, is_quiescence: bool) {
+        if !self.engine_options.use_transposition_tables {
+            return;
+        }
+        let new_entry = TTEntry { depth, value, bound, is_quiescence };
+        match self.tt.get(&hash) {
+            Some(existing) => {
+                let should_replace = (!existing.is_quiescence && !is_quiescence && new_entry.depth >= existing.depth)
+                    || (existing.is_quiescence && is_quiescence && new_entry.depth >= existing.depth)
+                    || (!existing.is_quiescence && is_quiescence);
+                if should_replace {
+                    self.tt.insert(hash, new_entry);
+                }
+            }
+            None => {
+                self.tt.insert(hash, new_entry);
+            }
+        }
+    }
+
+    // minimax now takes an explicit depth_level parameter so each level uses its own buffers
+    fn minimax(&mut self, game: &mut Game, depth: usize, mut alpha: i32, mut beta: i32, colour: Colour, depth_level: usize) -> i32 {
+        self.nodes += 1;
+        let hash = game.get_current_hash();
+
+        // TT lookup
+        if let Some(tt_value) = self.tt_lookup(hash, depth, false, &mut alpha, &mut beta) {
+            return tt_value;
+        }
 
         let move_start_index = self.move_buffer.len();
-
         Self::generate_and_order_moves(self, game, colour, move_start_index);
 
         if let Some(result) = game.is_game_over_with_moves(&self.move_buffer[move_start_index..], self.engine_options.magic_bitboards) {
             self.move_buffer.truncate(move_start_index);
-            return Evaluator::evaluate_game_result(game, Some(result), ply, colour);
+            return Evaluator::evaluate_game_result(game, Some(result), depth_level, colour);
         }
 
         if depth == 0 {
@@ -196,7 +225,7 @@ impl Minimax {
             game.make_move(&mv);
 
             // recursive call will generate into move_buffers[ply + 1]
-            let score = -self.minimax(game, depth - 1, -beta, -alpha, colour.other(), ply+1);
+            let score = -self.minimax(game, depth - 1, -beta, -alpha, colour.other(), depth_level + 1);
 
             game.undo_last_move();
 
@@ -211,73 +240,34 @@ impl Minimax {
             }
         }
 
-        if self.engine_options.use_transposition_tables {
-            let bound = if best_score <= orig_alpha {
-                Bound::Upper
-            } else if best_score >= beta {
-                Bound::Lower
-            } else {
-                Bound::Exact
-            };
-
-            let new_entry = TTEntry {
-                depth,
-                value: best_score,
-                bound,
-                is_quiescence: false,
-            };
-
-            match self.tt.get(&hash) {
-                Some(existing) => {
-                    let should_replace = (!existing.is_quiescence && new_entry.depth >= existing.depth)
-                        || (existing.is_quiescence && !new_entry.is_quiescence);
-                    if should_replace {
-                        self.tt.insert(hash, new_entry);
-                    }
-                }
-                None => {
-                    self.tt.insert(hash, new_entry);
-                }
-            }
-        }
+        // TT store
+        let bound = if best_score <= orig_alpha {
+            Bound::Upper
+        } else if best_score >= beta {
+            Bound::Lower
+        } else {
+            Bound::Exact
+        };
+        self.tt_store(hash, depth, best_score, bound, false);
 
         self.move_buffer.truncate(move_start_index);
         best_score
     }
 
-    // quiescence uses the tactical buffer for this ply
-    fn quiescence(
-        &mut self,
-        game: &mut Game,
-        mut alpha: i32,
-        mut beta: i32,
-        max_depth: usize,
-        ply: usize,
-    ) -> i32 {
+    fn quiescence(&mut self, game: &mut Game, mut alpha: i32, mut beta: i32, max_depth: usize, depth_level: usize) -> i32 {
         self.nodes += 1;
         let hash = game.get_current_hash();
 
-        if self.engine_options.use_transposition_tables {
-            if let Some(entry) = self.tt.get(&hash) {
-                if entry.is_quiescence && entry.depth >= max_depth {
-                    self.tt_hits += 1;
-                    match entry.bound {
-                        Bound::Exact => return entry.value,
-                        Bound::Lower => alpha = alpha.max(entry.value),
-                        Bound::Upper => beta = beta.min(entry.value),
-                    }
-                    if alpha >= beta {
-                        return entry.value;
-                    }
-                }
-            }
+        // TT lookup
+        if let Some(tt_value) = self.tt_lookup(hash, max_depth, true, &mut alpha, &mut beta) {
+            return tt_value;
         }
 
         let to_move = game.get_game_state().get_turn();
         let escape_check = game.is_player_in_check(to_move, self.engine_options.magic_bitboards);
 
         // stand pat
-        let stand_pat = Evaluator::evaluate_game_result(game, None, ply, to_move);
+        let stand_pat = Evaluator::evaluate_game_result(game, None, depth_level, to_move);
         if max_depth == 0 || (!escape_check && stand_pat >= beta) {
             return stand_pat;
         }
@@ -290,9 +280,10 @@ impl Minimax {
 
         if let Some(result) = game.is_game_over_with_moves(&self.move_buffer[move_start_index..], self.engine_options.magic_bitboards) {
             self.move_buffer.truncate(move_start_index);
-            return Evaluator::evaluate_game_result(game, Some(result), ply, to_move);
+            return Evaluator::evaluate_game_result(game, Some(result), depth_level, to_move);
         }
 
+        let orig_alpha = alpha;
         let mut best_score = if !escape_check {stand_pat} else {-INF};
 
         while self.move_buffer.len() > move_start_index {
@@ -301,7 +292,7 @@ impl Minimax {
                 continue
             }
             game.make_move(&mv);
-            let score = -self.quiescence(game, -beta, -alpha, max_depth - 1, ply + 1);
+            let score = -self.quiescence(game, -beta, -alpha, max_depth - 1, depth_level + 1);
             game.undo_last_move();
 
             if score >= beta {
@@ -316,27 +307,15 @@ impl Minimax {
             }
         }
 
-        // store quiescence result if using TT (same logic as before)
-        if self.engine_options.use_transposition_tables {
-            let new_entry = TTEntry {
-                depth: max_depth,
-                value: best_score,
-                bound: Bound::Exact,
-                is_quiescence: true,
-            };
-            match self.tt.get(&hash) {
-                Some(existing) => {
-                    let should_replace = (existing.is_quiescence && new_entry.depth >= existing.depth)
-                        || (!existing.is_quiescence);
-                    if should_replace {
-                        self.tt.insert(hash, new_entry);
-                    }
-                }
-                None => {
-                    self.tt.insert(hash, new_entry);
-                }
-            }
-        }
+        // TT store
+        let bound = if best_score <= orig_alpha {
+            Bound::Upper
+        } else if best_score >= beta {
+            Bound::Lower
+        } else {
+            Bound::Exact
+        };
+        self.tt_store(hash, max_depth, best_score, bound, true);
 
         best_score
     }

--- a/rust_chess/src/engine/minimax.rs
+++ b/rust_chess/src/engine/minimax.rs
@@ -88,13 +88,8 @@ impl Minimax {
         let mut best_score: i32 = -INF;
 
         self.move_buffer.clear();
-        MoveGenerator::generate_legal_moves_into(
-            game,
-            colour,
-            self.engine_options.magic_bitboards,
-            &mut self.move_buffer,
-        );
-        order_moves(&mut self.move_buffer[..], game);
+
+        Self::generate_and_order_moves(self, game, colour, 0);
 
         for depth in 1..=self.engine_options.max_depth {
             let mut current_best: Option<ChessMove> = None;
@@ -138,13 +133,7 @@ impl Minimax {
         let depth = self.engine_options.max_depth;
 
         self.move_buffer.clear();
-        MoveGenerator::generate_legal_moves_into(
-            game,
-            colour,
-            self.engine_options.magic_bitboards,
-            &mut self.move_buffer,
-        );
-        order_moves(&mut self.move_buffer, game);
+        Self::generate_and_order_moves(self, game, colour, 0);
 
         while let Some(mv) = self.move_buffer.pop()  {
             game.make_move(&mv);
@@ -186,14 +175,7 @@ impl Minimax {
 
         let move_start_index = self.move_buffer.len();
 
-        // generate moves into buffer for this ply
-        MoveGenerator::generate_legal_moves_into(
-            game,
-            colour,
-            self.engine_options.magic_bitboards,
-            &mut self.move_buffer,
-        );
-        order_moves(&mut self.move_buffer[move_start_index..], game);
+        Self::generate_and_order_moves(self, game, colour, move_start_index);
 
         if let Some(result) = game.is_game_over_with_moves(&self.move_buffer[move_start_index..], self.engine_options.magic_bitboards) {
             self.move_buffer.truncate(move_start_index);
@@ -303,14 +285,8 @@ impl Minimax {
         }
 
         let move_start_index = self.move_buffer.len();
-        // generate only tactical moves into the tactical buffer for this ply
-        MoveGenerator::generate_legal_moves_into(
-            game,
-            to_move,
-            self.engine_options.magic_bitboards,
-            &mut self.move_buffer,
-        );
-        order_moves(&mut self.move_buffer[move_start_index..], game);
+        Self::generate_and_order_moves(self, game, to_move, move_start_index);
+
         if let Some(result) = game.is_game_over_with_moves(&self.move_buffer[move_start_index..], self.engine_options.magic_bitboards) {
             self.move_buffer.truncate(move_start_index);
             return Evaluator::evaluate_game_result(game, Some(result), ply, to_move);
@@ -362,6 +338,17 @@ impl Minimax {
         }
 
         best_score
+    }
+
+    // Helper to generate and order moves starting from a given index in move_buffer
+    fn generate_and_order_moves(&mut self, game: &mut Game, colour: Colour, start_index: usize) {
+        MoveGenerator::generate_legal_moves_into(
+            game,
+            colour,
+            self.engine_options.magic_bitboards,
+            &mut self.move_buffer,
+        );
+        order_moves(&mut self.move_buffer[start_index..], game);
     }
 }
 

--- a/rust_chess/src/game_classes/game.rs
+++ b/rust_chess/src/game_classes/game.rs
@@ -101,7 +101,7 @@ impl Game {
         
     }
 
-    pub fn is_game_over_with_moves(&mut self, moves: &Vec<ChessMove>, magic_bitboard: bool) -> Option<GameResult> {
+    pub fn is_game_over_with_moves(&mut self, moves: &[ChessMove], magic_bitboard: bool) -> Option<GameResult> {
         let player = self.get_game_state().get_turn();
 
         if self.state_tracker.is_threefold_repetition(self.hash) {

--- a/rust_chess/src/lib.rs
+++ b/rust_chess/src/lib.rs
@@ -79,7 +79,7 @@ impl PyMinimax {
         let colour = self.game.get_game_state().get_turn();
         println!("Searching with depth {} (quiescence depth {})...", self.inner.engine_options.max_depth, self.inner.engine_options.quiescence_max_depth);
         // // println!("Current board eval: {}", self.inner.evaluate(&self.game, colour));
-        let best = self.inner.find_best_move(&mut self.game, colour);
+        let (best, _) = self.inner.find_best_move(&mut self.game, colour, false);
         return best.unwrap().to_string();
 
         // let moves = self.inner.find_sorted_moves(&mut self.game, colour);
@@ -96,10 +96,9 @@ impl PyMinimax {
         // let best = self.inner.find_best_move(&mut self.game, colour);
         // return best.unwrap().to_string();
 
-        self.inner.find_sorted_moves(&mut self.game, colour)
-            .iter()                          // iterate over & (ChessMove, i32)
-            .map(|(mv, score)| (mv.to_string(), *score))  // convert ChessMove -> String, copy the i32
-            .collect()
+        let (_, scores_opt) = self.inner.find_best_move(&mut self.game, colour, true);
+        let scores = scores_opt.unwrap();
+        scores.into_iter().map(|(mv, score)| (mv.to_string(), score)).collect()
     }
 
     pub fn set_position(&mut self, fenstr: &str, moves: Vec<String>) {
@@ -126,7 +125,7 @@ impl PyMinimax {
     }
 
     pub fn set_quiescence_max_depth(&mut self, quiescence_max_depth: usize) {
-        // self.inner.update_quiescnece_max_depth(quiescence_max_depth);
+        self.inner.engine_options.quiescence_max_depth = quiescence_max_depth;
     }
 
     pub fn set_use_transposition_tables(&mut self, use_tt: bool) {
@@ -150,7 +149,6 @@ impl PyMinimax {
         self.inner.engine_options.use_transposition_tables
     }
 
-    /// Optional: reset the engine TT if you want to start fresh
     pub fn clear_tt(&mut self) {
         self.inner.tt.clear();
     }

--- a/rust_chess/src/lib.rs
+++ b/rust_chess/src/lib.rs
@@ -179,7 +179,7 @@ impl PyMinimax {
         }
     }
 
-    pub fn unmake_move(&mut self, _mv: &str) {
+    pub fn unmake_move(&mut self) {
         self.game.undo_last_move();
     }
 }

--- a/rust_chess/src/lib.rs
+++ b/rust_chess/src/lib.rs
@@ -77,16 +77,17 @@ impl PyMinimax {
 
     pub fn go(&mut self) -> String {
         let colour = self.game.get_game_state().get_turn();
+        println!("Searching with depth {} (quiescence depth {})...", self.inner.engine_options.max_depth, self.inner.engine_options.quiescence_max_depth);
         // // println!("Current board eval: {}", self.inner.evaluate(&self.game, colour));
-        // let best = self.inner.find_best_move(&mut self.game, colour);
-        // return best.unwrap().to_string();
+        let best = self.inner.find_best_move(&mut self.game, colour);
+        return best.unwrap().to_string();
 
-        let moves = self.inner.find_sorted_moves(&mut self.game, colour);
-        for (mv, eval) in moves.iter().take(100) {
-            println!("{mv}: {eval}");
-        }
+        // let moves = self.inner.find_sorted_moves(&mut self.game, colour);
+        // for (mv, eval) in moves.iter().take(100) {
+        //     println!("{mv}: {eval}");
+        // }
 
-        return moves[0].0.to_string();
+        // return moves[0].0.to_string();
     }
 
     pub fn evaluate_moves(&mut self) -> Vec<(String, i32)> {
@@ -121,7 +122,7 @@ impl PyMinimax {
 
     /// Engine option setters
     pub fn set_max_depth(&mut self, max_depth: usize) {
-        // self.inner.update_max_depth(max_depth);
+        self.inner.engine_options.max_depth = max_depth;
     }
 
     pub fn set_quiescence_max_depth(&mut self, quiescence_max_depth: usize) {
@@ -182,28 +183,6 @@ impl PyMinimax {
 
     pub fn unmake_move(&mut self, _mv: &str) {
         self.game.undo_last_move();
-    }
-
-    pub fn perft(&mut self, depth: u32) -> u64 {
-        if depth == 0 {
-            return 1;
-        }
-
-        let moves = self.generate_legal_moves();
-
-        if depth == 1 {
-            return moves.len() as u64;
-        }
-
-        let mut nodes = 0;
-
-        for mv in moves {
-            self.make_move(&mv);
-            nodes += self.perft(depth - 1);
-            self.unmake_move(&mv);
-        }
-
-        nodes
     }
 }
 

--- a/rust_chess/src/move_ordering.rs
+++ b/rust_chess/src/move_ordering.rs
@@ -23,7 +23,7 @@ fn move_order_score(mv: &ChessMove, game: &Game) -> i32 {
     0
 }
 
-pub fn order_moves(moves: &mut Vec<ChessMove>, game: &Game) {
+pub fn order_moves(moves: &mut [ChessMove], game: &Game) {
     moves.sort_unstable_by_key(|mv| move_order_score(mv, game));
-    moves.reverse(); // highest score first
+    // moves.reverse(); // highest score first
 }

--- a/rust_chess/src/moves/move_generator.rs
+++ b/rust_chess/src/moves/move_generator.rs
@@ -30,8 +30,7 @@ impl MoveGenerator {
         magic_bitboard: bool,
         out_moves: &mut Vec<ChessMove>
     ) {
-        out_moves.clear();
-
+        let initial_len = out_moves.len();
         // generate pseudo-legal moves
         if magic_bitboard {
             Self::generate_pseudo_legal_moves_magic_bitboards_into(game, player, out_moves);
@@ -40,7 +39,7 @@ impl MoveGenerator {
         }
 
         // filter illegal moves in-place
-        let mut i = 0;
+        let mut i = initial_len;
         while i < out_moves.len() {
             if Self::does_leave_player_in_check(game, &out_moves[i], magic_bitboard) {
                 out_moves.swap_remove(i);
@@ -51,36 +50,6 @@ impl MoveGenerator {
 
         // append castling moves
         Self::generate_castling_moves_into(game, player, magic_bitboard, out_moves);
-    }
-
-    pub fn generate_tactical_moves_into(
-        game: &mut Game,
-        to_move: Colour,
-        use_magic: bool,
-        out: &mut Vec<ChessMove>,
-    ) {
-        // Clear the buffer first
-        out.clear();
-
-        // Generate all pseudo-legal moves first
-        let mut pseudo_moves = Vec::new();
-        if use_magic {
-            MoveGenerator::generate_pseudo_legal_moves_magic_bitboards_into(game, to_move, &mut pseudo_moves);
-        } else {
-            MoveGenerator::generate_pseudo_legal_moves_into(game, to_move, &mut pseudo_moves);
-        };
-
-        // Filter tactical moves: captures, promotions, en passant, checks
-        for mv in pseudo_moves {
-            let is_tactical = Self::is_tactical_move(game, &mv, use_magic);
-
-            if is_tactical {
-                // Optionally, skip moves that leave the king in check
-                if !MoveGenerator::does_leave_player_in_check(game, &mv, use_magic) {
-                    out.push(mv);
-                }
-            }
-        }
     }
 
     pub fn is_tactical_move(game: &mut Game, mv: &ChessMove, use_magic: bool) -> bool {
@@ -102,7 +71,6 @@ impl MoveGenerator {
         player: Colour,
         out_moves: &mut Vec<ChessMove>
     ) {
-        out_moves.clear();
         let all_occ = game.get_board().all_occ();
         let own_occ = game.get_board().get_colour_occ(player);
 
@@ -151,7 +119,6 @@ impl MoveGenerator {
         player: Colour,
         out_moves: &mut Vec<ChessMove>
     ) {
-        out_moves.clear();
         for (piece, coords) in &game.get_player_pieces(player) {
             for mv in Self::move_rays_to_chess_moves_into(game, piece, coords) {
                 out_moves.push(mv);

--- a/rust_chess/tests/integration_tests.rs
+++ b/rust_chess/tests/integration_tests.rs
@@ -162,7 +162,7 @@ fn test_iterative_deepening_tt_hits() {
 }
 
 #[test]
-fn test_nodes_per_second_comparison() {
+fn test_nodes_per_second_comparison_tt() {
     let mut engines = vec![
         ("No TT", PyMinimax::new(2, 4, false, false)),
         ("TT", PyMinimax::new(2, 4, true, false)),
@@ -214,8 +214,8 @@ fn test_nodes_per_second_comparison_magic_bitboards() {
 #[test]
 fn test_nodes_per_second_comparison_magic_bitboards_complicated() {
     let mut engines = vec![
-        ("Move Rays", PyMinimax::new(2, 4, false, false)),
-        ("Magic Bitboards", PyMinimax::new(2, 4, false, true)),
+        ("Move Rays", PyMinimax::new(3, 4, true, false)),
+        ("Magic Bitboards", PyMinimax::new(3, 4, true, true)),
     ];
 
 


### PR DESCRIPTION
The main change is that minimax no longer has a separate move buffer for each depth. Instead it uses a single global move buffer to store all moves. 

This PR also refactors and cleans up a lot of the minimax.rs file.

One key note is that move ordering is now in ascending order instead of descending. This change was made to work with the changes to the single move buffer in minimax.