### PR TITLE
Update perft tests. Modify move generation for more accurate perft results.

### DIFF
--- a/rust_chess/flamegraph.svg
+++ b/rust_chess/flamegraph.svg
@@ -1,0 +1,491 @@
+<?xml version="1.0" standalone="no"?><!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd"><svg version="1.1" width="1200" height="758" onload="init(evt)" viewBox="0 0 1200 758" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:fg="http://github.com/jonhoo/inferno"><!--Flame graph stack visualization. See https://github.com/brendangregg/FlameGraph for latest version, and http://www.brendangregg.com/flamegraphs.html for examples.--><!--NOTES: --><defs><linearGradient id="background" y1="0" y2="1" x1="0" x2="0"><stop stop-color="#eeeeee" offset="5%"/><stop stop-color="#eeeeb0" offset="95%"/></linearGradient></defs><style type="text/css">
+text { font-family:monospace; font-size:12px }
+#title { text-anchor:middle; font-size:17px; }
+#matched { text-anchor:end; }
+#search { text-anchor:end; opacity:0.1; cursor:pointer; }
+#search:hover, #search.show { opacity:1; }
+#subtitle { text-anchor:middle; font-color:rgb(160,160,160); }
+#unzoom { cursor:pointer; }
+#frames > *:hover { stroke:black; stroke-width:0.5; cursor:pointer; }
+.hide { display:none; }
+.parent { opacity:0.5; }
+</style><script type="text/ecmascript"><![CDATA[
+        var nametype = 'Function:';
+        var fontsize = 12;
+        var fontwidth = 0.59;
+        var xpad = 10;
+        var inverted = false;
+        var searchcolor = 'rgb(230,0,230)';
+        var fluiddrawing = true;
+        var truncate_text_right = false;
+    ]]><![CDATA["use strict";
+var details, searchbtn, unzoombtn, matchedtxt, svg, searching, frames, known_font_width;
+function init(evt) {
+    details = document.getElementById("details").firstChild;
+    searchbtn = document.getElementById("search");
+    unzoombtn = document.getElementById("unzoom");
+    matchedtxt = document.getElementById("matched");
+    svg = document.getElementsByTagName("svg")[0];
+    frames = document.getElementById("frames");
+    known_font_width = get_monospace_width(frames);
+    total_samples = parseInt(frames.attributes.total_samples.value);
+    searching = 0;
+
+    // Use GET parameters to restore a flamegraph's state.
+    var restore_state = function() {
+        var params = get_params();
+        if (params.x && params.y)
+            zoom(find_group(document.querySelector('[*|x="' + params.x + '"][y="' + params.y + '"]')));
+        if (params.s)
+            search(params.s);
+    };
+
+    if (fluiddrawing) {
+        // Make width dynamic so the SVG fits its parent's width.
+        svg.removeAttribute("width");
+        // Edge requires us to have a viewBox that gets updated with size changes.
+        var isEdge = /Edge\/\d./i.test(navigator.userAgent);
+        if (!isEdge) {
+            svg.removeAttribute("viewBox");
+        }
+        var update_for_width_change = function() {
+            if (isEdge) {
+                svg.attributes.viewBox.value = "0 0 " + svg.width.baseVal.value + " " + svg.height.baseVal.value;
+            }
+
+            // Keep consistent padding on left and right of frames container.
+            frames.attributes.width.value = svg.width.baseVal.value - xpad * 2;
+
+            // Text truncation needs to be adjusted for the current width.
+            update_text_for_elements(frames.children);
+
+            // Keep search elements at a fixed distance from right edge.
+            var svgWidth = svg.width.baseVal.value;
+            searchbtn.attributes.x.value = svgWidth - xpad;
+            matchedtxt.attributes.x.value = svgWidth - xpad;
+        };
+        window.addEventListener('resize', function() {
+            update_for_width_change();
+        });
+        // This needs to be done asynchronously for Safari to work.
+        setTimeout(function() {
+            unzoom();
+            update_for_width_change();
+            restore_state();
+        }, 0);
+    } else {
+        restore_state();
+    }
+}
+// event listeners
+window.addEventListener("click", function(e) {
+    var target = find_group(e.target);
+    if (target) {
+        if (target.nodeName == "a") {
+            if (e.ctrlKey === false) return;
+            e.preventDefault();
+        }
+        if (target.classList.contains("parent")) unzoom();
+        zoom(target);
+
+        // set parameters for zoom state
+        var el = target.querySelector("rect");
+        if (el && el.attributes && el.attributes.y && el.attributes["fg:x"]) {
+            var params = get_params()
+            params.x = el.attributes["fg:x"].value;
+            params.y = el.attributes.y.value;
+            history.replaceState(null, null, parse_params(params));
+        }
+    }
+    else if (e.target.id == "unzoom") {
+        unzoom();
+
+        // remove zoom state
+        var params = get_params();
+        if (params.x) delete params.x;
+        if (params.y) delete params.y;
+        history.replaceState(null, null, parse_params(params));
+    }
+    else if (e.target.id == "search") search_prompt();
+}, false)
+// mouse-over for info
+// show
+window.addEventListener("mouseover", function(e) {
+    var target = find_group(e.target);
+    if (target) details.nodeValue = nametype + " " + g_to_text(target);
+}, false)
+// clear
+window.addEventListener("mouseout", function(e) {
+    var target = find_group(e.target);
+    if (target) details.nodeValue = ' ';
+}, false)
+// ctrl-F for search
+window.addEventListener("keydown",function (e) {
+    if (e.keyCode === 114 || (e.ctrlKey && e.keyCode === 70)) {
+        e.preventDefault();
+        search_prompt();
+    }
+}, false)
+// functions
+function get_params() {
+    var params = {};
+    var paramsarr = window.location.search.substr(1).split('&');
+    for (var i = 0; i < paramsarr.length; ++i) {
+        var tmp = paramsarr[i].split("=");
+        if (!tmp[0] || !tmp[1]) continue;
+        params[tmp[0]]  = decodeURIComponent(tmp[1]);
+    }
+    return params;
+}
+function parse_params(params) {
+    var uri = "?";
+    for (var key in params) {
+        uri += key + '=' + encodeURIComponent(params[key]) + '&';
+    }
+    if (uri.slice(-1) == "&")
+        uri = uri.substring(0, uri.length - 1);
+    if (uri == '?')
+        uri = window.location.href.split('?')[0];
+    return uri;
+}
+function find_child(node, selector) {
+    var children = node.querySelectorAll(selector);
+    if (children.length) return children[0];
+    return;
+}
+function find_group(node) {
+    var parent = node.parentElement;
+    if (!parent) return;
+    if (parent.id == "frames") return node;
+    return find_group(parent);
+}
+function orig_save(e, attr, val) {
+    if (e.attributes["fg:orig_" + attr] != undefined) return;
+    if (e.attributes[attr] == undefined) return;
+    if (val == undefined) val = e.attributes[attr].value;
+    e.setAttribute("fg:orig_" + attr, val);
+}
+function orig_load(e, attr) {
+    if (e.attributes["fg:orig_"+attr] == undefined) return;
+    e.attributes[attr].value = e.attributes["fg:orig_" + attr].value;
+    e.removeAttribute("fg:orig_" + attr);
+}
+function g_to_text(e) {
+    var text = find_child(e, "title").firstChild.nodeValue;
+    return (text)
+}
+function g_to_func(e) {
+    var func = g_to_text(e);
+    // if there's any manipulation we want to do to the function
+    // name before it's searched, do it here before returning.
+    return (func);
+}
+function get_monospace_width(frames) {
+    // Given the id="frames" element, return the width of text characters if
+    // this is a monospace font, otherwise return 0.
+    text = find_child(frames.children[0], "text");
+    originalContent = text.textContent;
+    text.textContent = "!";
+    bangWidth = text.getComputedTextLength();
+    text.textContent = "W";
+    wWidth = text.getComputedTextLength();
+    text.textContent = originalContent;
+    if (bangWidth === wWidth) {
+        return bangWidth;
+    } else {
+        return 0;
+    }
+}
+function update_text_for_elements(elements) {
+    // In order to render quickly in the browser, you want to do one pass of
+    // reading attributes, and one pass of mutating attributes. See
+    // https://web.dev/avoid-large-complex-layouts-and-layout-thrashing/ for details.
+
+    // Fall back to inefficient calculation, if we're variable-width font.
+    // TODO This should be optimized somehow too.
+    if (known_font_width === 0) {
+        for (var i = 0; i < elements.length; i++) {
+            update_text(elements[i]);
+        }
+        return;
+    }
+
+    var textElemNewAttributes = [];
+    for (var i = 0; i < elements.length; i++) {
+        var e = elements[i];
+        var r = find_child(e, "rect");
+        var t = find_child(e, "text");
+        var w = parseFloat(r.attributes.width.value) * frames.attributes.width.value / 100 - 3;
+        var txt = find_child(e, "title").textContent.replace(/\([^(]*\)$/,"");
+        var newX = format_percent((parseFloat(r.attributes.x.value) + (100 * 3 / frames.attributes.width.value)));
+
+        // Smaller than this size won't fit anything
+        if (w < 2 * known_font_width) {
+            textElemNewAttributes.push([newX, ""]);
+            continue;
+        }
+
+        // Fit in full text width
+        if (txt.length * known_font_width < w) {
+            textElemNewAttributes.push([newX, txt]);
+            continue;
+        }
+
+        var substringLength = Math.floor(w / known_font_width) - 2;
+        if (truncate_text_right) {
+            // Truncate the right side of the text.
+            textElemNewAttributes.push([newX, txt.substring(0, substringLength) + ".."]);
+            continue;
+        } else {
+            // Truncate the left side of the text.
+            textElemNewAttributes.push([newX, ".." + txt.substring(txt.length - substringLength, txt.length)]);
+            continue;
+        }
+    }
+
+    console.assert(textElemNewAttributes.length === elements.length, "Resize failed, please file a bug at https://github.com/jonhoo/inferno/");
+
+    // Now that we know new textContent, set it all in one go so we don't refresh a bazillion times.
+    for (var i = 0; i < elements.length; i++) {
+        var e = elements[i];
+        var values = textElemNewAttributes[i];
+        var t = find_child(e, "text");
+        t.attributes.x.value = values[0];
+        t.textContent = values[1];
+    }
+}
+
+function update_text(e) {
+    var r = find_child(e, "rect");
+    var t = find_child(e, "text");
+    var w = parseFloat(r.attributes.width.value) * frames.attributes.width.value / 100 - 3;
+    var txt = find_child(e, "title").textContent.replace(/\([^(]*\)$/,"");
+    t.attributes.x.value = format_percent((parseFloat(r.attributes.x.value) + (100 * 3 / frames.attributes.width.value)));
+
+    // Smaller than this size won't fit anything
+    if (w < 2 * fontsize * fontwidth) {
+        t.textContent = "";
+        return;
+    }
+    t.textContent = txt;
+    // Fit in full text width
+    if (t.getComputedTextLength() < w)
+        return;
+    if (truncate_text_right) {
+        // Truncate the right side of the text.
+        for (var x = txt.length - 2; x > 0; x--) {
+            if (t.getSubStringLength(0, x + 2) <= w) {
+                t.textContent = txt.substring(0, x) + "..";
+                return;
+            }
+        }
+    } else {
+        // Truncate the left side of the text.
+        for (var x = 2; x < txt.length; x++) {
+            if (t.getSubStringLength(x - 2, txt.length) <= w) {
+                t.textContent = ".." + txt.substring(x, txt.length);
+                return;
+            }
+        }
+    }
+    t.textContent = "";
+}
+// zoom
+function zoom_reset(e) {
+    if (e.tagName == "rect") {
+        e.attributes.x.value = format_percent(100 * parseInt(e.attributes["fg:x"].value) / total_samples);
+        e.attributes.width.value = format_percent(100 * parseInt(e.attributes["fg:w"].value) / total_samples);
+    }
+    if (e.childNodes == undefined) return;
+    for(var i = 0, c = e.childNodes; i < c.length; i++) {
+        zoom_reset(c[i]);
+    }
+}
+function zoom_child(e, x, zoomed_width_samples) {
+    if (e.tagName == "text") {
+        var parent_x = parseFloat(find_child(e.parentNode, "rect[x]").attributes.x.value);
+        e.attributes.x.value = format_percent(parent_x + (100 * 3 / frames.attributes.width.value));
+    } else if (e.tagName == "rect") {
+        e.attributes.x.value = format_percent(100 * (parseInt(e.attributes["fg:x"].value) - x) / zoomed_width_samples);
+        e.attributes.width.value = format_percent(100 * parseInt(e.attributes["fg:w"].value) / zoomed_width_samples);
+    }
+    if (e.childNodes == undefined) return;
+    for(var i = 0, c = e.childNodes; i < c.length; i++) {
+        zoom_child(c[i], x, zoomed_width_samples);
+    }
+}
+function zoom_parent(e) {
+    if (e.attributes) {
+        if (e.attributes.x != undefined) {
+            e.attributes.x.value = "0.0%";
+        }
+        if (e.attributes.width != undefined) {
+            e.attributes.width.value = "100.0%";
+        }
+    }
+    if (e.childNodes == undefined) return;
+    for(var i = 0, c = e.childNodes; i < c.length; i++) {
+        zoom_parent(c[i]);
+    }
+}
+function zoom(node) {
+    var attr = find_child(node, "rect").attributes;
+    var width = parseInt(attr["fg:w"].value);
+    var xmin = parseInt(attr["fg:x"].value);
+    var xmax = xmin + width;
+    var ymin = parseFloat(attr.y.value);
+    unzoombtn.classList.remove("hide");
+    var el = frames.children;
+    var to_update_text = [];
+    for (var i = 0; i < el.length; i++) {
+        var e = el[i];
+        var a = find_child(e, "rect").attributes;
+        var ex = parseInt(a["fg:x"].value);
+        var ew = parseInt(a["fg:w"].value);
+        // Is it an ancestor
+        if (!inverted) {
+            var upstack = parseFloat(a.y.value) > ymin;
+        } else {
+            var upstack = parseFloat(a.y.value) < ymin;
+        }
+        if (upstack) {
+            // Direct ancestor
+            if (ex <= xmin && (ex+ew) >= xmax) {
+                e.classList.add("parent");
+                zoom_parent(e);
+                to_update_text.push(e);
+            }
+            // not in current path
+            else
+                e.classList.add("hide");
+        }
+        // Children maybe
+        else {
+            // no common path
+            if (ex < xmin || ex >= xmax) {
+                e.classList.add("hide");
+            }
+            else {
+                zoom_child(e, xmin, width);
+                to_update_text.push(e);
+            }
+        }
+    }
+    update_text_for_elements(to_update_text);
+}
+function unzoom() {
+    unzoombtn.classList.add("hide");
+    var el = frames.children;
+    for(var i = 0; i < el.length; i++) {
+        el[i].classList.remove("parent");
+        el[i].classList.remove("hide");
+        zoom_reset(el[i]);
+    }
+    update_text_for_elements(el);
+}
+// search
+function reset_search() {
+    var el = document.querySelectorAll("#frames rect");
+    for (var i = 0; i < el.length; i++) {
+        orig_load(el[i], "fill")
+    }
+    var params = get_params();
+    delete params.s;
+    history.replaceState(null, null, parse_params(params));
+}
+function search_prompt() {
+    if (!searching) {
+        var term = prompt("Enter a search term (regexp " +
+            "allowed, eg: ^ext4_)", "");
+        if (term != null) {
+            search(term)
+        }
+    } else {
+        reset_search();
+        searching = 0;
+        searchbtn.classList.remove("show");
+        searchbtn.firstChild.nodeValue = "Search"
+        matchedtxt.classList.add("hide");
+        matchedtxt.firstChild.nodeValue = ""
+    }
+}
+function search(term) {
+    var re = new RegExp(term);
+    var el = frames.children;
+    var matches = new Object();
+    var maxwidth = 0;
+    for (var i = 0; i < el.length; i++) {
+        var e = el[i];
+        // Skip over frames which are either not visible, or below the zoomed-to frame
+        if (e.classList.contains("hide") || e.classList.contains("parent")) {
+            continue;
+        }
+        var func = g_to_func(e);
+        var rect = find_child(e, "rect");
+        if (func == null || rect == null)
+            continue;
+        // Save max width. Only works as we have a root frame
+        var w = parseInt(rect.attributes["fg:w"].value);
+        if (w > maxwidth)
+            maxwidth = w;
+        if (func.match(re)) {
+            // highlight
+            var x = parseInt(rect.attributes["fg:x"].value);
+            orig_save(rect, "fill");
+            rect.attributes.fill.value = searchcolor;
+            // remember matches
+            if (matches[x] == undefined) {
+                matches[x] = w;
+            } else {
+                if (w > matches[x]) {
+                    // overwrite with parent
+                    matches[x] = w;
+                }
+            }
+            searching = 1;
+        }
+    }
+    if (!searching)
+        return;
+    var params = get_params();
+    params.s = term;
+    history.replaceState(null, null, parse_params(params));
+
+    searchbtn.classList.add("show");
+    searchbtn.firstChild.nodeValue = "Reset Search";
+    // calculate percent matched, excluding vertical overlap
+    var count = 0;
+    var lastx = -1;
+    var lastw = 0;
+    var keys = Array();
+    for (k in matches) {
+        if (matches.hasOwnProperty(k))
+            keys.push(k);
+    }
+    // sort the matched frames by their x location
+    // ascending, then width descending
+    keys.sort(function(a, b){
+        return a - b;
+    });
+    // Step through frames saving only the biggest bottom-up frames
+    // thanks to the sort order. This relies on the tree property
+    // where children are always smaller than their parents.
+    for (var k in keys) {
+        var x = parseInt(keys[k]);
+        var w = matches[keys[k]];
+        if (x >= lastx + lastw) {
+            count += w;
+            lastx = x;
+            lastw = w;
+        }
+    }
+    // display matched percent
+    matchedtxt.classList.remove("hide");
+    var pct = 100 * count / maxwidth;
+    if (pct != 100) pct = pct.toFixed(1);
+    matchedtxt.firstChild.nodeValue = "Matched: " + pct + "%";
+}
+function format_percent(n) {
+    return n.toFixed(4) + "%";
+}
+]]></script><rect x="0" y="0" width="100%" height="758" fill="url(#background)"/><text id="title" fill="rgb(0,0,0)" x="50.0000%" y="24.00">Flame Graph</text><text id="details" fill="rgb(0,0,0)" x="10" y="741.00"> </text><text id="unzoom" class="hide" fill="rgb(0,0,0)" x="10" y="24.00">Reset Zoom</text><text id="search" fill="rgb(0,0,0)" x="1190" y="24.00">Search</text><text id="matched" fill="rgb(0,0,0)" x="1190" y="741.00"> </text><svg id="frames" x="10" width="1180" total_samples="40"><g><title>`0x7FFFB8C4C510 (1 samples, 2.50%)</title><rect x="0.0000%" y="693" width="2.5000%" height="15" fill="rgb(227,0,7)" fg:x="0" fg:w="1"/><text x="0.2500%" y="703.50">`0..</text></g><g><title>`0x7FFFB8C35C98 (1 samples, 2.50%)</title><rect x="2.5000%" y="661" width="2.5000%" height="15" fill="rgb(217,0,24)" fg:x="1" fg:w="1"/><text x="2.7500%" y="671.50">`0..</text></g><g><title>`0x7FFFB8CAF621 (1 samples, 2.50%)</title><rect x="2.5000%" y="645" width="2.5000%" height="15" fill="rgb(221,193,54)" fg:x="1" fg:w="1"/><text x="2.7500%" y="655.50">`0..</text></g><g><title>`0x7FFFB8BDCCA4 (1 samples, 2.50%)</title><rect x="2.5000%" y="629" width="2.5000%" height="15" fill="rgb(248,212,6)" fg:x="1" fg:w="1"/><text x="2.7500%" y="639.50">`0..</text></g><g><title>`0x7FFFB8BDCDE4 (1 samples, 2.50%)</title><rect x="2.5000%" y="613" width="2.5000%" height="15" fill="rgb(208,68,35)" fg:x="1" fg:w="1"/><text x="2.7500%" y="623.50">`0..</text></g><g><title>`0x7FFFB8BDE259 (1 samples, 2.50%)</title><rect x="2.5000%" y="597" width="2.5000%" height="15" fill="rgb(232,128,0)" fg:x="1" fg:w="1"/><text x="2.7500%" y="607.50">`0..</text></g><g><title>`0x7FFFB8BDCCA4 (1 samples, 2.50%)</title><rect x="2.5000%" y="581" width="2.5000%" height="15" fill="rgb(207,160,47)" fg:x="1" fg:w="1"/><text x="2.7500%" y="591.50">`0..</text></g><g><title>`0x7FFFB8BDD0D1 (1 samples, 2.50%)</title><rect x="2.5000%" y="565" width="2.5000%" height="15" fill="rgb(228,23,34)" fg:x="1" fg:w="1"/><text x="2.7500%" y="575.50">`0..</text></g><g><title>`0x7FFFB8C12002 (1 samples, 2.50%)</title><rect x="2.5000%" y="549" width="2.5000%" height="15" fill="rgb(218,30,26)" fg:x="1" fg:w="1"/><text x="2.7500%" y="559.50">`0..</text></g><g><title>`0x7FFFB8C133DF (1 samples, 2.50%)</title><rect x="2.5000%" y="533" width="2.5000%" height="15" fill="rgb(220,122,19)" fg:x="1" fg:w="1"/><text x="2.7500%" y="543.50">`0..</text></g><g><title>`0x7FFFB8C13C73 (1 samples, 2.50%)</title><rect x="2.5000%" y="517" width="2.5000%" height="15" fill="rgb(250,228,42)" fg:x="1" fg:w="1"/><text x="2.7500%" y="527.50">`0..</text></g><g><title>`0x7FFFB8D21FC4 (1 samples, 2.50%)</title><rect x="2.5000%" y="501" width="2.5000%" height="15" fill="rgb(240,193,28)" fg:x="1" fg:w="1"/><text x="2.7500%" y="511.50">`0..</text></g><g><title>`0x7FFFB8BC3B11 (2 samples, 5.00%)</title><rect x="5.0000%" y="613" width="5.0000%" height="15" fill="rgb(216,20,37)" fg:x="2" fg:w="2"/><text x="5.2500%" y="623.50">`0x7FF..</text></g><g><title>`0x7FFFB8BC4089 (2 samples, 5.00%)</title><rect x="5.0000%" y="597" width="5.0000%" height="15" fill="rgb(206,188,39)" fg:x="2" fg:w="2"/><text x="5.2500%" y="607.50">`0x7FF..</text></g><g><title>`0x7FFFB8BCB250 (2 samples, 5.00%)</title><rect x="5.0000%" y="581" width="5.0000%" height="15" fill="rgb(217,207,13)" fg:x="2" fg:w="2"/><text x="5.2500%" y="591.50">`0x7FF..</text></g><g><title>`0x7FFFB8BCA5A3 (2 samples, 5.00%)</title><rect x="5.0000%" y="565" width="5.0000%" height="15" fill="rgb(231,73,38)" fg:x="2" fg:w="2"/><text x="5.2500%" y="575.50">`0x7FF..</text></g><g><title>`0x7FFFB8D22464 (2 samples, 5.00%)</title><rect x="5.0000%" y="549" width="5.0000%" height="15" fill="rgb(225,20,46)" fg:x="2" fg:w="2"/><text x="5.2500%" y="559.50">`0x7FF..</text></g><g><title>`0x7FFFB8BC4E1E (1 samples, 2.50%)</title><rect x="10.0000%" y="581" width="2.5000%" height="15" fill="rgb(210,31,41)" fg:x="4" fg:w="1"/><text x="10.2500%" y="591.50">`0..</text></g><g><title>`0x7FFFB8BC53DB (1 samples, 2.50%)</title><rect x="10.0000%" y="565" width="2.5000%" height="15" fill="rgb(221,200,47)" fg:x="4" fg:w="1"/><text x="10.2500%" y="575.50">`0..</text></g><g><title>`0x7FFFB8D221C4 (1 samples, 2.50%)</title><rect x="10.0000%" y="549" width="2.5000%" height="15" fill="rgb(226,26,5)" fg:x="4" fg:w="1"/><text x="10.2500%" y="559.50">`0..</text></g><g><title>`0x7FFFB8C341BA (4 samples, 10.00%)</title><rect x="5.0000%" y="629" width="10.0000%" height="15" fill="rgb(249,33,26)" fg:x="2" fg:w="4"/><text x="5.2500%" y="639.50">`0x7FFFB8C341BA</text></g><g><title>`0x7FFFB8BC3C3C (2 samples, 5.00%)</title><rect x="10.0000%" y="613" width="5.0000%" height="15" fill="rgb(235,183,28)" fg:x="4" fg:w="2"/><text x="10.2500%" y="623.50">`0x7FF..</text></g><g><title>`0x7FFFB8BC84CC (2 samples, 5.00%)</title><rect x="10.0000%" y="597" width="5.0000%" height="15" fill="rgb(221,5,38)" fg:x="4" fg:w="2"/><text x="10.2500%" y="607.50">`0x7FF..</text></g><g><title>`0x7FFFB8BC4F98 (1 samples, 2.50%)</title><rect x="12.5000%" y="581" width="2.5000%" height="15" fill="rgb(247,18,42)" fg:x="5" fg:w="1"/><text x="12.7500%" y="591.50">`0..</text></g><g><title>`0x7FFFB8BD794E (1 samples, 2.50%)</title><rect x="12.5000%" y="565" width="2.5000%" height="15" fill="rgb(241,131,45)" fg:x="5" fg:w="1"/><text x="12.7500%" y="575.50">`0..</text></g><g><title>`0x7FFFB8BD977E (1 samples, 2.50%)</title><rect x="12.5000%" y="549" width="2.5000%" height="15" fill="rgb(249,31,29)" fg:x="5" fg:w="1"/><text x="12.7500%" y="559.50">`0..</text></g><g><title>`0x7FFFB8BC49F1 (1 samples, 2.50%)</title><rect x="12.5000%" y="533" width="2.5000%" height="15" fill="rgb(225,111,53)" fg:x="5" fg:w="1"/><text x="12.7500%" y="543.50">`0..</text></g><g><title>`0x7FFFB8BC4E1E (1 samples, 2.50%)</title><rect x="12.5000%" y="517" width="2.5000%" height="15" fill="rgb(238,160,17)" fg:x="5" fg:w="1"/><text x="12.7500%" y="527.50">`0..</text></g><g><title>`0x7FFFB8BC53DB (1 samples, 2.50%)</title><rect x="12.5000%" y="501" width="2.5000%" height="15" fill="rgb(214,148,48)" fg:x="5" fg:w="1"/><text x="12.7500%" y="511.50">`0..</text></g><g><title>`0x7FFFB8D221C4 (1 samples, 2.50%)</title><rect x="12.5000%" y="485" width="2.5000%" height="15" fill="rgb(232,36,49)" fg:x="5" fg:w="1"/><text x="12.7500%" y="495.50">`0..</text></g><g><title>`0x7FFFB8C363C1 (5 samples, 12.50%)</title><rect x="5.0000%" y="661" width="12.5000%" height="15" fill="rgb(209,103,24)" fg:x="2" fg:w="5"/><text x="5.2500%" y="671.50">`0x7FFFB8C363C1</text></g><g><title>`0x7FFFB8C35180 (5 samples, 12.50%)</title><rect x="5.0000%" y="645" width="12.5000%" height="15" fill="rgb(229,88,8)" fg:x="2" fg:w="5"/><text x="5.2500%" y="655.50">`0x7FFFB8C35180</text></g><g><title>`0x7FFFB8C34281 (1 samples, 2.50%)</title><rect x="15.0000%" y="629" width="2.5000%" height="15" fill="rgb(213,181,19)" fg:x="6" fg:w="1"/><text x="15.2500%" y="639.50">`0..</text></g><g><title>`0x7FFFB8BFDACA (1 samples, 2.50%)</title><rect x="15.0000%" y="613" width="2.5000%" height="15" fill="rgb(254,191,54)" fg:x="6" fg:w="1"/><text x="15.2500%" y="623.50">`0..</text></g><g><title>`0x7FFFB8CE6D05 (1 samples, 2.50%)</title><rect x="15.0000%" y="597" width="2.5000%" height="15" fill="rgb(241,83,37)" fg:x="6" fg:w="1"/><text x="15.2500%" y="607.50">`0..</text></g><g><title>`0x7FFFB8BC83D4 (1 samples, 2.50%)</title><rect x="17.5000%" y="485" width="2.5000%" height="15" fill="rgb(233,36,39)" fg:x="7" fg:w="1"/><text x="17.7500%" y="495.50">`0..</text></g><g><title>`0x7FFFB8D22604 (1 samples, 2.50%)</title><rect x="17.5000%" y="469" width="2.5000%" height="15" fill="rgb(226,3,54)" fg:x="7" fg:w="1"/><text x="17.7500%" y="479.50">`0..</text></g><g><title>`0x7FFFB8BD7813 (1 samples, 2.50%)</title><rect x="20.0000%" y="453" width="2.5000%" height="15" fill="rgb(245,192,40)" fg:x="8" fg:w="1"/><text x="20.2500%" y="463.50">`0..</text></g><g><title>`0x7FFFB8D27CF0 (1 samples, 2.50%)</title><rect x="20.0000%" y="437" width="2.5000%" height="15" fill="rgb(238,167,29)" fg:x="8" fg:w="1"/><text x="20.2500%" y="447.50">`0..</text></g><g><title>`0x7FFFB8BD63A0 (3 samples, 7.50%)</title><rect x="17.5000%" y="533" width="7.5000%" height="15" fill="rgb(232,182,51)" fg:x="7" fg:w="3"/><text x="17.7500%" y="543.50">`0x7FFFB8B..</text></g><g><title>`0x7FFFB8C34294 (3 samples, 7.50%)</title><rect x="17.5000%" y="517" width="7.5000%" height="15" fill="rgb(231,60,39)" fg:x="7" fg:w="3"/><text x="17.7500%" y="527.50">`0x7FFFB8C..</text></g><g><title>`0x7FFFB8BC701D (3 samples, 7.50%)</title><rect x="17.5000%" y="501" width="7.5000%" height="15" fill="rgb(208,69,12)" fg:x="7" fg:w="3"/><text x="17.7500%" y="511.50">`0x7FFFB8B..</text></g><g><title>`0x7FFFB8BC84CC (2 samples, 5.00%)</title><rect x="20.0000%" y="485" width="5.0000%" height="15" fill="rgb(235,93,37)" fg:x="8" fg:w="2"/><text x="20.2500%" y="495.50">`0x7FF..</text></g><g><title>`0x7FFFB8BC4F98 (2 samples, 5.00%)</title><rect x="20.0000%" y="469" width="5.0000%" height="15" fill="rgb(213,116,39)" fg:x="8" fg:w="2"/><text x="20.2500%" y="479.50">`0x7FF..</text></g><g><title>`0x7FFFB8BD7AC2 (1 samples, 2.50%)</title><rect x="22.5000%" y="453" width="2.5000%" height="15" fill="rgb(222,207,29)" fg:x="9" fg:w="1"/><text x="22.7500%" y="463.50">`0..</text></g><g><title>`0x7FFFB8BFD939 (1 samples, 2.50%)</title><rect x="22.5000%" y="437" width="2.5000%" height="15" fill="rgb(206,96,30)" fg:x="9" fg:w="1"/><text x="22.7500%" y="447.50">`0..</text></g><g><title>`0x7FFFB60C0046 (4 samples, 10.00%)</title><rect x="17.5000%" y="645" width="10.0000%" height="15" fill="rgb(218,138,4)" fg:x="7" fg:w="4"/><text x="17.7500%" y="655.50">`0x7FFFB60C0046</text></g><g><title>`0x7FFFB60A553D (4 samples, 10.00%)</title><rect x="17.5000%" y="629" width="10.0000%" height="15" fill="rgb(250,191,14)" fg:x="7" fg:w="4"/><text x="17.7500%" y="639.50">`0x7FFFB60A553D</text></g><g><title>`0x7FFFB603423B (4 samples, 10.00%)</title><rect x="17.5000%" y="613" width="10.0000%" height="15" fill="rgb(239,60,40)" fg:x="7" fg:w="4"/><text x="17.7500%" y="623.50">`0x7FFFB603423B</text></g><g><title>`0x7FFFB6096225 (4 samples, 10.00%)</title><rect x="17.5000%" y="597" width="10.0000%" height="15" fill="rgb(206,27,48)" fg:x="7" fg:w="4"/><text x="17.7500%" y="607.50">`0x7FFFB6096225</text></g><g><title>`0x7FFFB623D29F (4 samples, 10.00%)</title><rect x="17.5000%" y="581" width="10.0000%" height="15" fill="rgb(225,35,8)" fg:x="7" fg:w="4"/><text x="17.7500%" y="591.50">`0x7FFFB623D29F</text></g><g><title>`0x7FFFB8BFFA20 (4 samples, 10.00%)</title><rect x="17.5000%" y="565" width="10.0000%" height="15" fill="rgb(250,213,24)" fg:x="7" fg:w="4"/><text x="17.7500%" y="575.50">`0x7FFFB8BFFA20</text></g><g><title>`0x7FFFB8BD6020 (4 samples, 10.00%)</title><rect x="17.5000%" y="549" width="10.0000%" height="15" fill="rgb(247,123,22)" fg:x="7" fg:w="4"/><text x="17.7500%" y="559.50">`0x7FFFB8BD6020</text></g><g><title>`0x7FFFB8BD6414 (1 samples, 2.50%)</title><rect x="25.0000%" y="533" width="2.5000%" height="15" fill="rgb(231,138,38)" fg:x="10" fg:w="1"/><text x="25.2500%" y="543.50">`0..</text></g><g><title>`0x7FFFB8C56203 (1 samples, 2.50%)</title><rect x="25.0000%" y="517" width="2.5000%" height="15" fill="rgb(231,145,46)" fg:x="10" fg:w="1"/><text x="25.2500%" y="527.50">`0..</text></g><g><title>`0x7FFFB8C57716 (1 samples, 2.50%)</title><rect x="25.0000%" y="501" width="2.5000%" height="15" fill="rgb(251,118,11)" fg:x="10" fg:w="1"/><text x="25.2500%" y="511.50">`0..</text></g><g><title>`0x7FFFB8C576EA (1 samples, 2.50%)</title><rect x="25.0000%" y="485" width="2.5000%" height="15" fill="rgb(217,147,25)" fg:x="10" fg:w="1"/><text x="25.2500%" y="495.50">`0..</text></g><g><title>`0x7FFFB8BC97AC (1 samples, 2.50%)</title><rect x="25.0000%" y="469" width="2.5000%" height="15" fill="rgb(247,81,37)" fg:x="10" fg:w="1"/><text x="25.2500%" y="479.50">`0..</text></g><g><title>`0x7FFFB8BCBCAE (1 samples, 2.50%)</title><rect x="25.0000%" y="453" width="2.5000%" height="15" fill="rgb(209,12,38)" fg:x="10" fg:w="1"/><text x="25.2500%" y="463.50">`0..</text></g><g><title>`0x7FFFB8D1F96E (1 samples, 2.50%)</title><rect x="25.0000%" y="437" width="2.5000%" height="15" fill="rgb(227,1,9)" fg:x="10" fg:w="1"/><text x="25.2500%" y="447.50">`0..</text></g><g><title>`0x7FFFB7517AAF (1 samples, 2.50%)</title><rect x="25.0000%" y="421" width="2.5000%" height="15" fill="rgb(248,47,43)" fg:x="10" fg:w="1"/><text x="25.2500%" y="431.50">`0..</text></g><g><title>`0x7FFFB7534762 (1 samples, 2.50%)</title><rect x="25.0000%" y="405" width="2.5000%" height="15" fill="rgb(221,10,30)" fg:x="10" fg:w="1"/><text x="25.2500%" y="415.50">`0..</text></g><g><title>`0x7FFFB75348D0 (1 samples, 2.50%)</title><rect x="25.0000%" y="389" width="2.5000%" height="15" fill="rgb(210,229,1)" fg:x="10" fg:w="1"/><text x="25.2500%" y="399.50">`0..</text></g><g><title>`0x7FFFB752D89B (1 samples, 2.50%)</title><rect x="25.0000%" y="373" width="2.5000%" height="15" fill="rgb(222,148,37)" fg:x="10" fg:w="1"/><text x="25.2500%" y="383.50">`0..</text></g><g><title>`0x7FFFB752D6B0 (1 samples, 2.50%)</title><rect x="25.0000%" y="357" width="2.5000%" height="15" fill="rgb(234,67,33)" fg:x="10" fg:w="1"/><text x="25.2500%" y="367.50">`0..</text></g><g><title>`0x7FFFB8BDCCA4 (1 samples, 2.50%)</title><rect x="25.0000%" y="341" width="2.5000%" height="15" fill="rgb(247,98,35)" fg:x="10" fg:w="1"/><text x="25.2500%" y="351.50">`0..</text></g><g><title>`0x7FFFB8BDD0D1 (1 samples, 2.50%)</title><rect x="25.0000%" y="325" width="2.5000%" height="15" fill="rgb(247,138,52)" fg:x="10" fg:w="1"/><text x="25.2500%" y="335.50">`0..</text></g><g><title>`0x7FFFB8C115DF (1 samples, 2.50%)</title><rect x="25.0000%" y="309" width="2.5000%" height="15" fill="rgb(213,79,30)" fg:x="10" fg:w="1"/><text x="25.2500%" y="319.50">`0..</text></g><g><title>`0x7FFFB60C0093 (1 samples, 2.50%)</title><rect x="27.5000%" y="645" width="2.5000%" height="15" fill="rgb(246,177,23)" fg:x="11" fg:w="1"/><text x="27.7500%" y="655.50">`0..</text></g><g><title>`0x7FFFB74818AB (1 samples, 2.50%)</title><rect x="27.5000%" y="629" width="2.5000%" height="15" fill="rgb(230,62,27)" fg:x="11" fg:w="1"/><text x="27.7500%" y="639.50">`0..</text></g><g><title>`0x7FFFB8C4C67E (1 samples, 2.50%)</title><rect x="27.5000%" y="613" width="2.5000%" height="15" fill="rgb(216,154,8)" fg:x="11" fg:w="1"/><text x="27.7500%" y="623.50">`0..</text></g><g><title>`0x7FFFB8C4D4AF (1 samples, 2.50%)</title><rect x="27.5000%" y="597" width="2.5000%" height="15" fill="rgb(244,35,45)" fg:x="11" fg:w="1"/><text x="27.7500%" y="607.50">`0..</text></g><g><title>`0x7FFFB8BCBCAE (1 samples, 2.50%)</title><rect x="27.5000%" y="581" width="2.5000%" height="15" fill="rgb(251,115,12)" fg:x="11" fg:w="1"/><text x="27.7500%" y="591.50">`0..</text></g><g><title>`0x7FFFB8D1F96E (1 samples, 2.50%)</title><rect x="27.5000%" y="565" width="2.5000%" height="15" fill="rgb(240,54,50)" fg:x="11" fg:w="1"/><text x="27.7500%" y="575.50">`0..</text></g><g><title>`0x7FFFB62BDDCD (1 samples, 2.50%)</title><rect x="27.5000%" y="549" width="2.5000%" height="15" fill="rgb(233,84,52)" fg:x="11" fg:w="1"/><text x="27.7500%" y="559.50">`0..</text></g><g><title>`0x7FFFB62BD403 (1 samples, 2.50%)</title><rect x="27.5000%" y="533" width="2.5000%" height="15" fill="rgb(207,117,47)" fg:x="11" fg:w="1"/><text x="27.7500%" y="543.50">`0..</text></g><g><title>`0x7FFFB628A921 (1 samples, 2.50%)</title><rect x="27.5000%" y="517" width="2.5000%" height="15" fill="rgb(249,43,39)" fg:x="11" fg:w="1"/><text x="27.7500%" y="527.50">`0..</text></g><g><title>`0x7FFFB624FD18 (1 samples, 2.50%)</title><rect x="27.5000%" y="501" width="2.5000%" height="15" fill="rgb(209,38,44)" fg:x="11" fg:w="1"/><text x="27.7500%" y="511.50">`0..</text></g><g><title>`0x7FFFB8C9FFF1 (1 samples, 2.50%)</title><rect x="27.5000%" y="485" width="2.5000%" height="15" fill="rgb(236,212,23)" fg:x="11" fg:w="1"/><text x="27.7500%" y="495.50">`0..</text></g><g><title>`0x7FFFB8D27D14 (1 samples, 2.50%)</title><rect x="27.5000%" y="469" width="2.5000%" height="15" fill="rgb(242,79,21)" fg:x="11" fg:w="1"/><text x="27.7500%" y="479.50">`0..</text></g><g><title>perft-61337ab0e760586f.exe`test::cli::parse_opts (1 samples, 2.50%)</title><rect x="32.5000%" y="405" width="2.5000%" height="15" fill="rgb(211,96,35)" fg:x="13" fg:w="1"/><text x="32.7500%" y="415.50">pe..</text></g><g><title>perft-61337ab0e760586f.exe`test::cli::parse_opts_impl (1 samples, 2.50%)</title><rect x="32.5000%" y="389" width="2.5000%" height="15" fill="rgb(253,215,40)" fg:x="13" fg:w="1"/><text x="32.7500%" y="399.50">pe..</text></g><g><title>perft-61337ab0e760586f.exe`core::result::impl$27::branch (1 samples, 2.50%)</title><rect x="32.5000%" y="373" width="2.5000%" height="15" fill="rgb(211,81,21)" fg:x="13" fg:w="1"/><text x="32.7500%" y="383.50">pe..</text></g><g><title>perft-61337ab0e760586f.exe`test::cli::get_nocapture (1 samples, 2.50%)</title><rect x="32.5000%" y="357" width="2.5000%" height="15" fill="rgb(208,190,38)" fg:x="13" fg:w="1"/><text x="32.7500%" y="367.50">pe..</text></g><g><title>perft-61337ab0e760586f.exe`std::env::_var (1 samples, 2.50%)</title><rect x="32.5000%" y="341" width="2.5000%" height="15" fill="rgb(235,213,38)" fg:x="13" fg:w="1"/><text x="32.7500%" y="351.50">pe..</text></g><g><title>perft-61337ab0e760586f.exe`std::env::_var_os (1 samples, 2.50%)</title><rect x="32.5000%" y="325" width="2.5000%" height="15" fill="rgb(237,122,38)" fg:x="13" fg:w="1"/><text x="32.7500%" y="335.50">pe..</text></g><g><title>perft-61337ab0e760586f.exe`std::sys::env::windows::getenv (1 samples, 2.50%)</title><rect x="32.5000%" y="309" width="2.5000%" height="15" fill="rgb(244,218,35)" fg:x="13" fg:w="1"/><text x="32.7500%" y="319.50">pe..</text></g><g><title>perft-61337ab0e760586f.exe`core::result::Result::ok (1 samples, 2.50%)</title><rect x="32.5000%" y="293" width="2.5000%" height="15" fill="rgb(240,68,47)" fg:x="13" fg:w="1"/><text x="32.7500%" y="303.50">pe..</text></g><g><title>perft-61337ab0e760586f.exe`std::sys::pal::windows::to_u16s::inner (1 samples, 2.50%)</title><rect x="32.5000%" y="277" width="2.5000%" height="15" fill="rgb(210,16,53)" fg:x="13" fg:w="1"/><text x="32.7500%" y="287.50">pe..</text></g><g><title>perft-61337ab0e760586f.exe`alloc::vec::impl$8::deref (1 samples, 2.50%)</title><rect x="32.5000%" y="261" width="2.5000%" height="15" fill="rgb(235,124,12)" fg:x="13" fg:w="1"/><text x="32.7500%" y="271.50">pe..</text></g><g><title>perft-61337ab0e760586f.exe`alloc::vec::Vec::as_slice (1 samples, 2.50%)</title><rect x="32.5000%" y="245" width="2.5000%" height="15" fill="rgb(224,169,11)" fg:x="13" fg:w="1"/><text x="32.7500%" y="255.50">pe..</text></g><g><title>perft-61337ab0e760586f.exe`alloc::vec::Vec::as_ptr (1 samples, 2.50%)</title><rect x="32.5000%" y="229" width="2.5000%" height="15" fill="rgb(250,166,2)" fg:x="13" fg:w="1"/><text x="32.7500%" y="239.50">pe..</text></g><g><title>perft-61337ab0e760586f.exe`alloc::raw_vec::RawVec::ptr (1 samples, 2.50%)</title><rect x="32.5000%" y="213" width="2.5000%" height="15" fill="rgb(242,216,29)" fg:x="13" fg:w="1"/><text x="32.7500%" y="223.50">pe..</text></g><g><title>perft-61337ab0e760586f.exe`alloc::raw_vec::RawVecInner::ptr (1 samples, 2.50%)</title><rect x="32.5000%" y="197" width="2.5000%" height="15" fill="rgb(230,116,27)" fg:x="13" fg:w="1"/><text x="32.7500%" y="207.50">pe..</text></g><g><title>perft-61337ab0e760586f.exe`alloc::raw_vec::RawVecInner::non_null (1 samples, 2.50%)</title><rect x="32.5000%" y="181" width="2.5000%" height="15" fill="rgb(228,99,48)" fg:x="13" fg:w="1"/><text x="32.7500%" y="191.50">pe..</text></g><g><title>perft-61337ab0e760586f.exe`alloc::vec::Vec::extend_desugared&lt;u16,alloc::alloc::Global,std::sys_common::wtf8::EncodeWide&gt; (1 samples, 2.50%)</title><rect x="32.5000%" y="165" width="2.5000%" height="15" fill="rgb(253,11,6)" fg:x="13" fg:w="1"/><text x="32.7500%" y="175.50">pe..</text></g><g><title>perft-61337ab0e760586f.exe`std::sys_common::wtf8::impl$18::next (1 samples, 2.50%)</title><rect x="32.5000%" y="149" width="2.5000%" height="15" fill="rgb(247,143,39)" fg:x="13" fg:w="1"/><text x="32.7500%" y="159.50">pe..</text></g><g><title>perft-61337ab0e760586f.exe`std::sys_common::wtf8::impl$17::next (1 samples, 2.50%)</title><rect x="32.5000%" y="133" width="2.5000%" height="15" fill="rgb(236,97,10)" fg:x="13" fg:w="1"/><text x="32.7500%" y="143.50">pe..</text></g><g><title>perft-61337ab0e760586f.exe`core::str::validations::next_code_point (1 samples, 2.50%)</title><rect x="32.5000%" y="117" width="2.5000%" height="15" fill="rgb(233,208,19)" fg:x="13" fg:w="1"/><text x="32.7500%" y="127.50">pe..</text></g><g><title>perft-61337ab0e760586f.exe`test::formatters::pretty::impl$1::write_run_finish&lt;std::io::stdio::Stdout&gt; (1 samples, 2.50%)</title><rect x="35.0000%" y="389" width="2.5000%" height="15" fill="rgb(216,164,2)" fg:x="14" fg:w="1"/><text x="35.2500%" y="399.50">pe..</text></g><g><title>perft-61337ab0e760586f.exe`core::result::impl$27::branch (1 samples, 2.50%)</title><rect x="35.0000%" y="373" width="2.5000%" height="15" fill="rgb(220,129,5)" fg:x="14" fg:w="1"/><text x="35.2500%" y="383.50">pe..</text></g><g><title>perft-61337ab0e760586f.exe`std::io::stdio::impl$15::flush (1 samples, 2.50%)</title><rect x="35.0000%" y="357" width="2.5000%" height="15" fill="rgb(242,17,10)" fg:x="14" fg:w="1"/><text x="35.2500%" y="367.50">pe..</text></g><g><title>perft-61337ab0e760586f.exe`std::io::stdio::impl$16::flush (1 samples, 2.50%)</title><rect x="35.0000%" y="341" width="2.5000%" height="15" fill="rgb(242,107,0)" fg:x="14" fg:w="1"/><text x="35.2500%" y="351.50">pe..</text></g><g><title>perft-61337ab0e760586f.exe`std::io::stdio::impl$19::flush (1 samples, 2.50%)</title><rect x="35.0000%" y="325" width="2.5000%" height="15" fill="rgb(251,28,31)" fg:x="14" fg:w="1"/><text x="35.2500%" y="335.50">pe..</text></g><g><title>perft-61337ab0e760586f.exe`core::ptr::drop_in_place (1 samples, 2.50%)</title><rect x="35.0000%" y="309" width="2.5000%" height="15" fill="rgb(233,223,10)" fg:x="14" fg:w="1"/><text x="35.2500%" y="319.50">pe..</text></g><g><title>perft-61337ab0e760586f.exe`core::ptr::drop_in_place (1 samples, 2.50%)</title><rect x="35.0000%" y="293" width="2.5000%" height="15" fill="rgb(215,21,27)" fg:x="14" fg:w="1"/><text x="35.2500%" y="303.50">pe..</text></g><g><title>perft-61337ab0e760586f.exe`core::cell::impl$42::drop (1 samples, 2.50%)</title><rect x="35.0000%" y="277" width="2.5000%" height="15" fill="rgb(232,23,21)" fg:x="14" fg:w="1"/><text x="35.2500%" y="287.50">pe..</text></g><g><title>perft-61337ab0e760586f.exe`core::cell::Cell::set (1 samples, 2.50%)</title><rect x="35.0000%" y="261" width="2.5000%" height="15" fill="rgb(244,5,23)" fg:x="14" fg:w="1"/><text x="35.2500%" y="271.50">pe..</text></g><g><title>perft-61337ab0e760586f.exe`core::cell::Cell::replace (1 samples, 2.50%)</title><rect x="35.0000%" y="245" width="2.5000%" height="15" fill="rgb(226,81,46)" fg:x="14" fg:w="1"/><text x="35.2500%" y="255.50">pe..</text></g><g><title>perft-61337ab0e760586f.exe`core::mem::replace (1 samples, 2.50%)</title><rect x="35.0000%" y="229" width="2.5000%" height="15" fill="rgb(247,70,30)" fg:x="14" fg:w="1"/><text x="35.2500%" y="239.50">pe..</text></g><g><title>perft-61337ab0e760586f.exe`std::io::buffered::bufwriter::BufWriter::flush_buf&lt;std::io::stdio::StdoutRaw&gt; (1 samples, 2.50%)</title><rect x="35.0000%" y="213" width="2.5000%" height="15" fill="rgb(212,68,19)" fg:x="14" fg:w="1"/><text x="35.2500%" y="223.50">pe..</text></g><g><title>perft-61337ab0e760586f.exe`std::io::stdio::impl$1::write (1 samples, 2.50%)</title><rect x="35.0000%" y="197" width="2.5000%" height="15" fill="rgb(240,187,13)" fg:x="14" fg:w="1"/><text x="35.2500%" y="207.50">pe..</text></g><g><title>perft-61337ab0e760586f.exe`std::io::stdio::handle_ebadf (1 samples, 2.50%)</title><rect x="35.0000%" y="181" width="2.5000%" height="15" fill="rgb(223,113,26)" fg:x="14" fg:w="1"/><text x="35.2500%" y="191.50">pe..</text></g><g><title>perft-61337ab0e760586f.exe`std::sys::stdio::windows::write (1 samples, 2.50%)</title><rect x="35.0000%" y="165" width="2.5000%" height="15" fill="rgb(206,192,2)" fg:x="14" fg:w="1"/><text x="35.2500%" y="175.50">pe..</text></g><g><title>perft-61337ab0e760586f.exe`std::sys::stdio::windows::write_console_utf16 (1 samples, 2.50%)</title><rect x="35.0000%" y="149" width="2.5000%" height="15" fill="rgb(241,108,4)" fg:x="14" fg:w="1"/><text x="35.2500%" y="159.50">pe..</text></g><g><title>perft-61337ab0e760586f.exe`std::sys::stdio::windows::write_valid_utf8_to_console (1 samples, 2.50%)</title><rect x="35.0000%" y="133" width="2.5000%" height="15" fill="rgb(247,173,49)" fg:x="14" fg:w="1"/><text x="35.2500%" y="143.50">pe..</text></g><g><title>perft-61337ab0e760586f.exe`std::sys::stdio::windows::write_u16s (1 samples, 2.50%)</title><rect x="35.0000%" y="117" width="2.5000%" height="15" fill="rgb(224,114,35)" fg:x="14" fg:w="1"/><text x="35.2500%" y="127.50">pe..</text></g><g><title>perft-61337ab0e760586f.exe`std::sys::pal::windows::cvt (1 samples, 2.50%)</title><rect x="35.0000%" y="101" width="2.5000%" height="15" fill="rgb(245,159,27)" fg:x="14" fg:w="1"/><text x="35.2500%" y="111.50">pe..</text></g><g><title>perft-61337ab0e760586f.exe`std::sys::pal::windows::impl$3::is_zero (1 samples, 2.50%)</title><rect x="35.0000%" y="85" width="2.5000%" height="15" fill="rgb(245,172,44)" fg:x="14" fg:w="1"/><text x="35.2500%" y="95.50">pe..</text></g><g><title>`0x7FFFB62FC6DE (1 samples, 2.50%)</title><rect x="35.0000%" y="69" width="2.5000%" height="15" fill="rgb(236,23,11)" fg:x="14" fg:w="1"/><text x="35.2500%" y="79.50">`0..</text></g><g><title>`0x7FFFB62FC81C (1 samples, 2.50%)</title><rect x="35.0000%" y="53" width="2.5000%" height="15" fill="rgb(205,117,38)" fg:x="14" fg:w="1"/><text x="35.2500%" y="63.50">`0..</text></g><g><title>`0x7FFFB8D21DA4 (1 samples, 2.50%)</title><rect x="35.0000%" y="37" width="2.5000%" height="15" fill="rgb(237,72,25)" fg:x="14" fg:w="1"/><text x="35.2500%" y="47.50">`0..</text></g><g><title>`0x7FF69B42100C (4 samples, 10.00%)</title><rect x="30.0000%" y="533" width="10.0000%" height="15" fill="rgb(244,70,9)" fg:x="12" fg:w="4"/><text x="30.2500%" y="543.50">`0x7FF69B42100C</text></g><g><title>perft-61337ab0e760586f.exe`Unknown (4 samples, 10.00%)</title><rect x="30.0000%" y="517" width="10.0000%" height="15" fill="rgb(217,125,39)" fg:x="12" fg:w="4"/><text x="30.2500%" y="527.50">perft-61337ab0..</text></g><g><title>perft-61337ab0e760586f.exe`test::test_main_static (4 samples, 10.00%)</title><rect x="30.0000%" y="501" width="10.0000%" height="15" fill="rgb(235,36,10)" fg:x="12" fg:w="4"/><text x="30.2500%" y="511.50">perft-61337ab0..</text></g><g><title>perft-61337ab0e760586f.exe`core::ptr::drop_in_place (3 samples, 7.50%)</title><rect x="32.5000%" y="485" width="7.5000%" height="15" fill="rgb(251,123,47)" fg:x="13" fg:w="3"/><text x="32.7500%" y="495.50">perft-6133..</text></g><g><title>perft-61337ab0e760586f.exe`alloc::vec::impl$25::drop (3 samples, 7.50%)</title><rect x="32.5000%" y="469" width="7.5000%" height="15" fill="rgb(221,13,13)" fg:x="13" fg:w="3"/><text x="32.7500%" y="479.50">perft-6133..</text></g><g><title>perft-61337ab0e760586f.exe`core::ptr::drop_in_place (3 samples, 7.50%)</title><rect x="32.5000%" y="453" width="7.5000%" height="15" fill="rgb(238,131,9)" fg:x="13" fg:w="3"/><text x="32.7500%" y="463.50">perft-6133..</text></g><g><title>perft-61337ab0e760586f.exe`test::test_main (3 samples, 7.50%)</title><rect x="32.5000%" y="437" width="7.5000%" height="15" fill="rgb(211,50,8)" fg:x="13" fg:w="3"/><text x="32.7500%" y="447.50">perft-6133..</text></g><g><title>perft-61337ab0e760586f.exe`test::test_main_with_exit_callback (3 samples, 7.50%)</title><rect x="32.5000%" y="421" width="7.5000%" height="15" fill="rgb(245,182,24)" fg:x="13" fg:w="3"/><text x="32.7500%" y="431.50">perft-6133..</text></g><g><title>perft-61337ab0e760586f.exe`test::console::run_tests_console (2 samples, 5.00%)</title><rect x="35.0000%" y="405" width="5.0000%" height="15" fill="rgb(242,14,37)" fg:x="14" fg:w="2"/><text x="35.2500%" y="415.50">perft-..</text></g><g><title>perft-61337ab0e760586f.exe`test::run_tests (1 samples, 2.50%)</title><rect x="37.5000%" y="389" width="2.5000%" height="15" fill="rgb(246,228,12)" fg:x="15" fg:w="1"/><text x="37.7500%" y="399.50">pe..</text></g><g><title>perft-61337ab0e760586f.exe`test::console::run_tests_console::closure$2 (1 samples, 2.50%)</title><rect x="37.5000%" y="373" width="2.5000%" height="15" fill="rgb(213,55,15)" fg:x="15" fg:w="1"/><text x="37.7500%" y="383.50">pe..</text></g><g><title>perft-61337ab0e760586f.exe`test::console::on_test_event (1 samples, 2.50%)</title><rect x="37.5000%" y="357" width="2.5000%" height="15" fill="rgb(209,9,3)" fg:x="15" fg:w="1"/><text x="37.7500%" y="367.50">pe..</text></g><g><title>perft-61337ab0e760586f.exe`test::formatters::pretty::impl$1::write_run_start&lt;std::io::stdio::Stdout&gt; (1 samples, 2.50%)</title><rect x="37.5000%" y="341" width="2.5000%" height="15" fill="rgb(230,59,30)" fg:x="15" fg:w="1"/><text x="37.7500%" y="351.50">pe..</text></g><g><title>`0x7FFFB8C4C53C (16 samples, 40.00%)</title><rect x="2.5000%" y="693" width="40.0000%" height="15" fill="rgb(209,121,21)" fg:x="1" fg:w="16"/><text x="2.7500%" y="703.50">`0x7FFFB8C4C53C</text></g><g><title>`0x7FFFB746E8D7 (16 samples, 40.00%)</title><rect x="2.5000%" y="677" width="40.0000%" height="15" fill="rgb(220,109,13)" fg:x="1" fg:w="16"/><text x="2.7500%" y="687.50">`0x7FFFB746E8D7</text></g><g><title>perft-61337ab0e760586f.exe`__scrt_common_main_seh() (10 samples, 25.00%)</title><rect x="17.5000%" y="661" width="25.0000%" height="15" fill="rgb(232,18,1)" fg:x="7" fg:w="10"/><text x="17.7500%" y="671.50">perft-61337ab0e760586f.exe`__scrt_common..</text></g><g><title>perft-61337ab0e760586f.exe`invoke_main() (5 samples, 12.50%)</title><rect x="30.0000%" y="645" width="12.5000%" height="15" fill="rgb(215,41,42)" fg:x="12" fg:w="5"/><text x="30.2500%" y="655.50">perft-61337ab0e7605..</text></g><g><title>perft-61337ab0e760586f.exe`main (5 samples, 12.50%)</title><rect x="30.0000%" y="629" width="12.5000%" height="15" fill="rgb(224,123,36)" fg:x="12" fg:w="5"/><text x="30.2500%" y="639.50">perft-61337ab0e7605..</text></g><g><title>perft-61337ab0e760586f.exe`std::rt::lang_start_internal (5 samples, 12.50%)</title><rect x="30.0000%" y="613" width="12.5000%" height="15" fill="rgb(240,125,3)" fg:x="12" fg:w="5"/><text x="30.2500%" y="623.50">perft-61337ab0e7605..</text></g><g><title>perft-61337ab0e760586f.exe`std::panic::catch_unwind (5 samples, 12.50%)</title><rect x="30.0000%" y="597" width="12.5000%" height="15" fill="rgb(205,98,50)" fg:x="12" fg:w="5"/><text x="30.2500%" y="607.50">perft-61337ab0e7605..</text></g><g><title>perft-61337ab0e760586f.exe`std::panicking::catch_unwind (5 samples, 12.50%)</title><rect x="30.0000%" y="581" width="12.5000%" height="15" fill="rgb(205,185,37)" fg:x="12" fg:w="5"/><text x="30.2500%" y="591.50">perft-61337ab0e7605..</text></g><g><title>perft-61337ab0e760586f.exe`std::panicking::catch_unwind::do_call (5 samples, 12.50%)</title><rect x="30.0000%" y="565" width="12.5000%" height="15" fill="rgb(238,207,15)" fg:x="12" fg:w="5"/><text x="30.2500%" y="575.50">perft-61337ab0e7605..</text></g><g><title>perft-61337ab0e760586f.exe`std::rt::lang_start_internal::closure$0 (5 samples, 12.50%)</title><rect x="30.0000%" y="549" width="12.5000%" height="15" fill="rgb(213,199,42)" fg:x="12" fg:w="5"/><text x="30.2500%" y="559.50">perft-61337ab0e7605..</text></g><g><title>perft-61337ab0e760586f.exe`std::rt::cleanup (1 samples, 2.50%)</title><rect x="40.0000%" y="533" width="2.5000%" height="15" fill="rgb(235,201,11)" fg:x="16" fg:w="1"/><text x="40.2500%" y="543.50">pe..</text></g><g><title>perft-61337ab0e760586f.exe`std::sync::poison::once::Once::call_once (1 samples, 2.50%)</title><rect x="40.0000%" y="517" width="2.5000%" height="15" fill="rgb(207,46,11)" fg:x="16" fg:w="1"/><text x="40.2500%" y="527.50">pe..</text></g><g><title>perft-61337ab0e760586f.exe`std::sys::sync::once::futex::Once::call (1 samples, 2.50%)</title><rect x="40.0000%" y="501" width="2.5000%" height="15" fill="rgb(241,35,35)" fg:x="16" fg:w="1"/><text x="40.2500%" y="511.50">pe..</text></g><g><title>`0x7FFFB8C7C271 (1 samples, 2.50%)</title><rect x="42.5000%" y="645" width="2.5000%" height="15" fill="rgb(243,32,47)" fg:x="17" fg:w="1"/><text x="42.7500%" y="655.50">`0..</text></g><g><title>`0x7FFFB8C6D85D (1 samples, 2.50%)</title><rect x="42.5000%" y="629" width="2.5000%" height="15" fill="rgb(247,202,23)" fg:x="17" fg:w="1"/><text x="42.7500%" y="639.50">`0..</text></g><g><title>`0x7FFFB8C6E49C (1 samples, 2.50%)</title><rect x="42.5000%" y="613" width="2.5000%" height="15" fill="rgb(219,102,11)" fg:x="17" fg:w="1"/><text x="42.7500%" y="623.50">`0..</text></g><g><title>`0x7FFFB8D21F04 (1 samples, 2.50%)</title><rect x="42.5000%" y="597" width="2.5000%" height="15" fill="rgb(243,110,44)" fg:x="17" fg:w="1"/><text x="42.7500%" y="607.50">`0..</text></g><g><title>`0x7FFFB8C7C7A1 (1 samples, 2.50%)</title><rect x="45.0000%" y="645" width="2.5000%" height="15" fill="rgb(222,74,54)" fg:x="18" fg:w="1"/><text x="45.2500%" y="655.50">`0..</text></g><g><title>`0x7FFFB8CA972B (1 samples, 2.50%)</title><rect x="45.0000%" y="629" width="2.5000%" height="15" fill="rgb(216,99,12)" fg:x="18" fg:w="1"/><text x="45.2500%" y="639.50">`0..</text></g><g><title>`0x7FFFB8CA97D1 (1 samples, 2.50%)</title><rect x="45.0000%" y="613" width="2.5000%" height="15" fill="rgb(226,22,26)" fg:x="18" fg:w="1"/><text x="45.2500%" y="623.50">`0..</text></g><g><title>`0x7FFFB8CA98FA (1 samples, 2.50%)</title><rect x="45.0000%" y="597" width="2.5000%" height="15" fill="rgb(217,163,10)" fg:x="18" fg:w="1"/><text x="45.2500%" y="607.50">`0..</text></g><g><title>`0x7FFFB8CA9A33 (1 samples, 2.50%)</title><rect x="45.0000%" y="581" width="2.5000%" height="15" fill="rgb(213,25,53)" fg:x="18" fg:w="1"/><text x="45.2500%" y="591.50">`0..</text></g><g><title>`0x7FFFB8CA9B12 (1 samples, 2.50%)</title><rect x="45.0000%" y="565" width="2.5000%" height="15" fill="rgb(252,105,26)" fg:x="18" fg:w="1"/><text x="45.2500%" y="575.50">`0..</text></g><g><title>`0x7FFFB8CDC881 (1 samples, 2.50%)</title><rect x="45.0000%" y="549" width="2.5000%" height="15" fill="rgb(220,39,43)" fg:x="18" fg:w="1"/><text x="45.2500%" y="559.50">`0..</text></g><g><title>`0x7FFFB8D317B2 (1 samples, 2.50%)</title><rect x="45.0000%" y="533" width="2.5000%" height="15" fill="rgb(229,68,48)" fg:x="18" fg:w="1"/><text x="45.2500%" y="543.50">`0..</text></g><g><title>`0x7FFFB8D31140 (1 samples, 2.50%)</title><rect x="45.0000%" y="517" width="2.5000%" height="15" fill="rgb(252,8,32)" fg:x="18" fg:w="1"/><text x="45.2500%" y="527.50">`0..</text></g><g><title>`0x7FFFB8D313E3 (1 samples, 2.50%)</title><rect x="45.0000%" y="501" width="2.5000%" height="15" fill="rgb(223,20,43)" fg:x="18" fg:w="1"/><text x="45.2500%" y="511.50">`0..</text></g><g><title>`0x7FFFB8E280C0 (1 samples, 2.50%)</title><rect x="45.0000%" y="485" width="2.5000%" height="15" fill="rgb(229,81,49)" fg:x="18" fg:w="1"/><text x="45.2500%" y="495.50">`0..</text></g><g><title>`0x7FFFB8C7C8D8 (1 samples, 2.50%)</title><rect x="47.5000%" y="645" width="2.5000%" height="15" fill="rgb(236,28,36)" fg:x="19" fg:w="1"/><text x="47.7500%" y="655.50">`0..</text></g><g><title>`0x7FFFB8C5AB73 (1 samples, 2.50%)</title><rect x="47.5000%" y="629" width="2.5000%" height="15" fill="rgb(249,185,26)" fg:x="19" fg:w="1"/><text x="47.7500%" y="639.50">`0..</text></g><g><title>`0x7FFFB8C5AECF (1 samples, 2.50%)</title><rect x="47.5000%" y="613" width="2.5000%" height="15" fill="rgb(249,174,33)" fg:x="19" fg:w="1"/><text x="47.7500%" y="623.50">`0..</text></g><g><title>`0x7FFFB8C5B98A (1 samples, 2.50%)</title><rect x="47.5000%" y="597" width="2.5000%" height="15" fill="rgb(233,201,37)" fg:x="19" fg:w="1"/><text x="47.7500%" y="607.50">`0..</text></g><g><title>`0x7FFFB8D25654 (1 samples, 2.50%)</title><rect x="47.5000%" y="581" width="2.5000%" height="15" fill="rgb(221,78,26)" fg:x="19" fg:w="1"/><text x="47.7500%" y="591.50">`0..</text></g><g><title>`0x7FFFB8C7C919 (1 samples, 2.50%)</title><rect x="50.0000%" y="645" width="2.5000%" height="15" fill="rgb(250,127,30)" fg:x="20" fg:w="1"/><text x="50.2500%" y="655.50">`0..</text></g><g><title>`0x7FFFB8C1FB43 (1 samples, 2.50%)</title><rect x="50.0000%" y="629" width="2.5000%" height="15" fill="rgb(230,49,44)" fg:x="20" fg:w="1"/><text x="50.2500%" y="639.50">`0..</text></g><g><title>`0x7FFFB8C1FCD1 (1 samples, 2.50%)</title><rect x="50.0000%" y="613" width="2.5000%" height="15" fill="rgb(229,67,23)" fg:x="20" fg:w="1"/><text x="50.2500%" y="623.50">`0..</text></g><g><title>`0x7FFFB8C20B82 (1 samples, 2.50%)</title><rect x="50.0000%" y="597" width="2.5000%" height="15" fill="rgb(249,83,47)" fg:x="20" fg:w="1"/><text x="50.2500%" y="607.50">`0..</text></g><g><title>`0x7FFFB8D25774 (1 samples, 2.50%)</title><rect x="50.0000%" y="581" width="2.5000%" height="15" fill="rgb(215,43,3)" fg:x="20" fg:w="1"/><text x="50.2500%" y="591.50">`0..</text></g><g><title>`0x7FFFB8C7D21A (1 samples, 2.50%)</title><rect x="52.5000%" y="645" width="2.5000%" height="15" fill="rgb(238,154,13)" fg:x="21" fg:w="1"/><text x="52.7500%" y="655.50">`0..</text></g><g><title>`0x7FFFB8BC20BF (1 samples, 2.50%)</title><rect x="52.5000%" y="629" width="2.5000%" height="15" fill="rgb(219,56,2)" fg:x="21" fg:w="1"/><text x="52.7500%" y="639.50">`0..</text></g><g><title>`0x7FFFB8BC1F30 (1 samples, 2.50%)</title><rect x="52.5000%" y="613" width="2.5000%" height="15" fill="rgb(233,0,4)" fg:x="21" fg:w="1"/><text x="52.7500%" y="623.50">`0..</text></g><g><title>`0x7FFFB8D22324 (1 samples, 2.50%)</title><rect x="52.5000%" y="597" width="2.5000%" height="15" fill="rgb(235,30,7)" fg:x="21" fg:w="1"/><text x="52.7500%" y="607.50">`0..</text></g><g><title>`0x7FFFB8BC4E1E (1 samples, 2.50%)</title><rect x="55.0000%" y="533" width="2.5000%" height="15" fill="rgb(250,79,13)" fg:x="22" fg:w="1"/><text x="55.2500%" y="543.50">`0..</text></g><g><title>`0x7FFFB8BC53DB (1 samples, 2.50%)</title><rect x="55.0000%" y="517" width="2.5000%" height="15" fill="rgb(211,146,34)" fg:x="22" fg:w="1"/><text x="55.2500%" y="527.50">`0..</text></g><g><title>`0x7FFFB8D221C4 (1 samples, 2.50%)</title><rect x="55.0000%" y="501" width="2.5000%" height="15" fill="rgb(228,22,38)" fg:x="22" fg:w="1"/><text x="55.2500%" y="511.50">`0..</text></g><g><title>`0x7FFFB8BD794E (1 samples, 2.50%)</title><rect x="57.5000%" y="517" width="2.5000%" height="15" fill="rgb(235,168,5)" fg:x="23" fg:w="1"/><text x="57.7500%" y="527.50">`0..</text></g><g><title>`0x7FFFB8BD977E (1 samples, 2.50%)</title><rect x="57.5000%" y="501" width="2.5000%" height="15" fill="rgb(221,155,16)" fg:x="23" fg:w="1"/><text x="57.7500%" y="511.50">`0..</text></g><g><title>`0x7FFFB8BC49F1 (1 samples, 2.50%)</title><rect x="57.5000%" y="485" width="2.5000%" height="15" fill="rgb(215,215,53)" fg:x="23" fg:w="1"/><text x="57.7500%" y="495.50">`0..</text></g><g><title>`0x7FFFB8BC4E1E (1 samples, 2.50%)</title><rect x="57.5000%" y="469" width="2.5000%" height="15" fill="rgb(223,4,10)" fg:x="23" fg:w="1"/><text x="57.7500%" y="479.50">`0..</text></g><g><title>`0x7FFFB8BC53DB (1 samples, 2.50%)</title><rect x="57.5000%" y="453" width="2.5000%" height="15" fill="rgb(234,103,6)" fg:x="23" fg:w="1"/><text x="57.7500%" y="463.50">`0..</text></g><g><title>`0x7FFFB8D221C4 (1 samples, 2.50%)</title><rect x="57.5000%" y="437" width="2.5000%" height="15" fill="rgb(227,97,0)" fg:x="23" fg:w="1"/><text x="57.7500%" y="447.50">`0..</text></g><g><title>`0x7FFFB8BFD5E5 (1 samples, 2.50%)</title><rect x="60.0000%" y="501" width="2.5000%" height="15" fill="rgb(234,150,53)" fg:x="24" fg:w="1"/><text x="60.2500%" y="511.50">`0..</text></g><g><title>`0x7FFFB8BD6382 (4 samples, 10.00%)</title><rect x="55.0000%" y="581" width="10.0000%" height="15" fill="rgb(228,201,54)" fg:x="22" fg:w="4"/><text x="55.2500%" y="591.50">`0x7FFFB8BD6382</text></g><g><title>`0x7FFFB8BDAD95 (4 samples, 10.00%)</title><rect x="55.0000%" y="565" width="10.0000%" height="15" fill="rgb(222,22,37)" fg:x="22" fg:w="4"/><text x="55.2500%" y="575.50">`0x7FFFB8BDAD95</text></g><g><title>`0x7FFFB8BC49F1 (4 samples, 10.00%)</title><rect x="55.0000%" y="549" width="10.0000%" height="15" fill="rgb(237,53,32)" fg:x="22" fg:w="4"/><text x="55.2500%" y="559.50">`0x7FFFB8BC49F1</text></g><g><title>`0x7FFFB8BC4F98 (3 samples, 7.50%)</title><rect x="57.5000%" y="533" width="7.5000%" height="15" fill="rgb(233,25,53)" fg:x="23" fg:w="3"/><text x="57.7500%" y="543.50">`0x7FFFB8B..</text></g><g><title>`0x7FFFB8BD7AC2 (2 samples, 5.00%)</title><rect x="60.0000%" y="517" width="5.0000%" height="15" fill="rgb(210,40,34)" fg:x="24" fg:w="2"/><text x="60.2500%" y="527.50">`0x7FF..</text></g><g><title>`0x7FFFB8BFD939 (1 samples, 2.50%)</title><rect x="62.5000%" y="501" width="2.5000%" height="15" fill="rgb(241,220,44)" fg:x="25" fg:w="1"/><text x="62.7500%" y="511.50">`0..</text></g><g><title>`0x7FFFB8BD63AA (1 samples, 2.50%)</title><rect x="65.0000%" y="581" width="2.5000%" height="15" fill="rgb(235,28,35)" fg:x="26" fg:w="1"/><text x="65.2500%" y="591.50">`0..</text></g><g><title>`0x7FFFB8C4CF87 (1 samples, 2.50%)</title><rect x="65.0000%" y="565" width="2.5000%" height="15" fill="rgb(210,56,17)" fg:x="26" fg:w="1"/><text x="65.2500%" y="575.50">`0..</text></g><g><title>`0x7FFFB8C34281 (1 samples, 2.50%)</title><rect x="65.0000%" y="549" width="2.5000%" height="15" fill="rgb(224,130,29)" fg:x="26" fg:w="1"/><text x="65.2500%" y="559.50">`0..</text></g><g><title>`0x7FFFB8BFD939 (1 samples, 2.50%)</title><rect x="65.0000%" y="533" width="2.5000%" height="15" fill="rgb(235,212,8)" fg:x="26" fg:w="1"/><text x="65.2500%" y="543.50">`0..</text></g><g><title>`0x7FFFB62BDC8D (1 samples, 2.50%)</title><rect x="67.5000%" y="469" width="2.5000%" height="15" fill="rgb(223,33,50)" fg:x="27" fg:w="1"/><text x="67.7500%" y="479.50">`0..</text></g><g><title>`0x7FFFB6233F86 (1 samples, 2.50%)</title><rect x="67.5000%" y="453" width="2.5000%" height="15" fill="rgb(219,149,13)" fg:x="27" fg:w="1"/><text x="67.7500%" y="463.50">`0..</text></g><g><title>`0x7FFFB6232C08 (1 samples, 2.50%)</title><rect x="67.5000%" y="437" width="2.5000%" height="15" fill="rgb(250,156,29)" fg:x="27" fg:w="1"/><text x="67.7500%" y="447.50">`0..</text></g><g><title>`0x7FFFB6232AD0 (1 samples, 2.50%)</title><rect x="67.5000%" y="421" width="2.5000%" height="15" fill="rgb(216,193,19)" fg:x="27" fg:w="1"/><text x="67.7500%" y="431.50">`0..</text></g><g><title>`0x7FFFB623243E (1 samples, 2.50%)</title><rect x="67.5000%" y="405" width="2.5000%" height="15" fill="rgb(216,135,14)" fg:x="27" fg:w="1"/><text x="67.7500%" y="415.50">`0..</text></g><g><title>`0x7FFFB623C98A (1 samples, 2.50%)</title><rect x="67.5000%" y="389" width="2.5000%" height="15" fill="rgb(241,47,5)" fg:x="27" fg:w="1"/><text x="67.7500%" y="399.50">`0..</text></g><g><title>`0x7FFFB8D23CF4 (1 samples, 2.50%)</title><rect x="67.5000%" y="373" width="2.5000%" height="15" fill="rgb(233,42,35)" fg:x="27" fg:w="1"/><text x="67.7500%" y="383.50">`0..</text></g><g><title>`0x7FFFB62BDD3F (1 samples, 2.50%)</title><rect x="70.0000%" y="469" width="2.5000%" height="15" fill="rgb(231,13,6)" fg:x="28" fg:w="1"/><text x="70.2500%" y="479.50">`0..</text></g><g><title>`0x7FFFB62BD3CE (1 samples, 2.50%)</title><rect x="70.0000%" y="453" width="2.5000%" height="15" fill="rgb(207,181,40)" fg:x="28" fg:w="1"/><text x="70.2500%" y="463.50">`0..</text></g><g><title>`0x7FFFB628A45B (1 samples, 2.50%)</title><rect x="70.0000%" y="437" width="2.5000%" height="15" fill="rgb(254,173,49)" fg:x="28" fg:w="1"/><text x="70.2500%" y="447.50">`0..</text></g><g><title>`0x7FFFB628D24D (1 samples, 2.50%)</title><rect x="70.0000%" y="421" width="2.5000%" height="15" fill="rgb(221,1,38)" fg:x="28" fg:w="1"/><text x="70.2500%" y="431.50">`0..</text></g><g><title>`0x7FFFB628E3FC (1 samples, 2.50%)</title><rect x="70.0000%" y="405" width="2.5000%" height="15" fill="rgb(206,124,46)" fg:x="28" fg:w="1"/><text x="70.2500%" y="415.50">`0..</text></g><g><title>`0x7FFFB624FC86 (1 samples, 2.50%)</title><rect x="70.0000%" y="389" width="2.5000%" height="15" fill="rgb(249,21,11)" fg:x="28" fg:w="1"/><text x="70.2500%" y="399.50">`0..</text></g><g><title>`0x7FFFB8BD5587 (1 samples, 2.50%)</title><rect x="70.0000%" y="373" width="2.5000%" height="15" fill="rgb(222,201,40)" fg:x="28" fg:w="1"/><text x="70.2500%" y="383.50">`0..</text></g><g><title>`0x7FFFB8BD51D0 (1 samples, 2.50%)</title><rect x="70.0000%" y="357" width="2.5000%" height="15" fill="rgb(235,61,29)" fg:x="28" fg:w="1"/><text x="70.2500%" y="367.50">`0..</text></g><g><title>`0x7FFFB8C0119E (1 samples, 2.50%)</title><rect x="70.0000%" y="341" width="2.5000%" height="15" fill="rgb(219,207,3)" fg:x="28" fg:w="1"/><text x="70.2500%" y="351.50">`0..</text></g><g><title>`0x7FFFB8C01CF2 (1 samples, 2.50%)</title><rect x="70.0000%" y="325" width="2.5000%" height="15" fill="rgb(222,56,46)" fg:x="28" fg:w="1"/><text x="70.2500%" y="335.50">`0..</text></g><g><title>`0x7FFFB8C03D2E (1 samples, 2.50%)</title><rect x="70.0000%" y="309" width="2.5000%" height="15" fill="rgb(239,76,54)" fg:x="28" fg:w="1"/><text x="70.2500%" y="319.50">`0..</text></g><g><title>`0x7FFFB8C04452 (1 samples, 2.50%)</title><rect x="70.0000%" y="293" width="2.5000%" height="15" fill="rgb(231,124,27)" fg:x="28" fg:w="1"/><text x="70.2500%" y="303.50">`0..</text></g><g><title>`0x7FFFB8C04CDA (1 samples, 2.50%)</title><rect x="70.0000%" y="277" width="2.5000%" height="15" fill="rgb(249,195,6)" fg:x="28" fg:w="1"/><text x="70.2500%" y="287.50">`0..</text></g><g><title>`0x7FFFB8C04F45 (1 samples, 2.50%)</title><rect x="70.0000%" y="261" width="2.5000%" height="15" fill="rgb(237,174,47)" fg:x="28" fg:w="1"/><text x="70.2500%" y="271.50">`0..</text></g><g><title>`0x7FFFB8CE4041 (1 samples, 2.50%)</title><rect x="70.0000%" y="245" width="2.5000%" height="15" fill="rgb(206,201,31)" fg:x="28" fg:w="1"/><text x="70.2500%" y="255.50">`0..</text></g><g><title>`0x7FFFB8C9AE85 (1 samples, 2.50%)</title><rect x="70.0000%" y="229" width="2.5000%" height="15" fill="rgb(231,57,52)" fg:x="28" fg:w="1"/><text x="70.2500%" y="239.50">`0..</text></g><g><title>`0x7FFFB8C58B04 (8 samples, 20.00%)</title><rect x="55.0000%" y="629" width="20.0000%" height="15" fill="rgb(248,177,22)" fg:x="22" fg:w="8"/><text x="55.2500%" y="639.50">`0x7FFFB8C58B04</text></g><g><title>`0x7FFFB8BFFA20 (8 samples, 20.00%)</title><rect x="55.0000%" y="613" width="20.0000%" height="15" fill="rgb(215,211,37)" fg:x="22" fg:w="8"/><text x="55.2500%" y="623.50">`0x7FFFB8BFFA20</text></g><g><title>`0x7FFFB8BD6020 (8 samples, 20.00%)</title><rect x="55.0000%" y="597" width="20.0000%" height="15" fill="rgb(241,128,51)" fg:x="22" fg:w="8"/><text x="55.2500%" y="607.50">`0x7FFFB8BD6020</text></g><g><title>`0x7FFFB8BD6414 (3 samples, 7.50%)</title><rect x="67.5000%" y="581" width="7.5000%" height="15" fill="rgb(227,165,31)" fg:x="27" fg:w="3"/><text x="67.7500%" y="591.50">`0x7FFFB8B..</text></g><g><title>`0x7FFFB8C56203 (3 samples, 7.50%)</title><rect x="67.5000%" y="565" width="7.5000%" height="15" fill="rgb(228,167,24)" fg:x="27" fg:w="3"/><text x="67.7500%" y="575.50">`0x7FFFB8C..</text></g><g><title>`0x7FFFB8C57716 (3 samples, 7.50%)</title><rect x="67.5000%" y="549" width="7.5000%" height="15" fill="rgb(228,143,12)" fg:x="27" fg:w="3"/><text x="67.7500%" y="559.50">`0x7FFFB8C..</text></g><g><title>`0x7FFFB8C576EA (3 samples, 7.50%)</title><rect x="67.5000%" y="533" width="7.5000%" height="15" fill="rgb(249,149,8)" fg:x="27" fg:w="3"/><text x="67.7500%" y="543.50">`0x7FFFB8C..</text></g><g><title>`0x7FFFB8BC97AC (3 samples, 7.50%)</title><rect x="67.5000%" y="517" width="7.5000%" height="15" fill="rgb(243,35,44)" fg:x="27" fg:w="3"/><text x="67.7500%" y="527.50">`0x7FFFB8B..</text></g><g><title>`0x7FFFB8BCBCAE (3 samples, 7.50%)</title><rect x="67.5000%" y="501" width="7.5000%" height="15" fill="rgb(246,89,9)" fg:x="27" fg:w="3"/><text x="67.7500%" y="511.50">`0x7FFFB8B..</text></g><g><title>`0x7FFFB8D1F96E (3 samples, 7.50%)</title><rect x="67.5000%" y="485" width="7.5000%" height="15" fill="rgb(233,213,13)" fg:x="27" fg:w="3"/><text x="67.7500%" y="495.50">`0x7FFFB8D..</text></g><g><title>`0x7FFFB62BDD49 (1 samples, 2.50%)</title><rect x="72.5000%" y="469" width="2.5000%" height="15" fill="rgb(233,141,41)" fg:x="29" fg:w="1"/><text x="72.7500%" y="479.50">`0..</text></g><g><title>`0x7FFFB62BD4D8 (1 samples, 2.50%)</title><rect x="72.5000%" y="453" width="2.5000%" height="15" fill="rgb(239,167,4)" fg:x="29" fg:w="1"/><text x="72.7500%" y="463.50">`0..</text></g><g><title>`0x7FFFB62BD5D5 (1 samples, 2.50%)</title><rect x="72.5000%" y="437" width="2.5000%" height="15" fill="rgb(209,217,16)" fg:x="29" fg:w="1"/><text x="72.7500%" y="447.50">`0..</text></g><g><title>`0x7FFFB631F081 (1 samples, 2.50%)</title><rect x="72.5000%" y="421" width="2.5000%" height="15" fill="rgb(219,88,35)" fg:x="29" fg:w="1"/><text x="72.7500%" y="431.50">`0..</text></g><g><title>`0x7FFFB63268CC (1 samples, 2.50%)</title><rect x="72.5000%" y="405" width="2.5000%" height="15" fill="rgb(220,193,23)" fg:x="29" fg:w="1"/><text x="72.7500%" y="415.50">`0..</text></g><g><title>`0x7FFFB63269CB (1 samples, 2.50%)</title><rect x="72.5000%" y="389" width="2.5000%" height="15" fill="rgb(230,90,52)" fg:x="29" fg:w="1"/><text x="72.7500%" y="399.50">`0..</text></g><g><title>`0x7FFFB6326A33 (1 samples, 2.50%)</title><rect x="72.5000%" y="373" width="2.5000%" height="15" fill="rgb(252,106,19)" fg:x="29" fg:w="1"/><text x="72.7500%" y="383.50">`0..</text></g><g><title>`0x7FFFB6326B8A (1 samples, 2.50%)</title><rect x="72.5000%" y="357" width="2.5000%" height="15" fill="rgb(206,74,20)" fg:x="29" fg:w="1"/><text x="72.7500%" y="367.50">`0..</text></g><g><title>`0x7FFFB628AB10 (1 samples, 2.50%)</title><rect x="72.5000%" y="341" width="2.5000%" height="15" fill="rgb(230,138,44)" fg:x="29" fg:w="1"/><text x="72.7500%" y="351.50">`0..</text></g><g><title>`0x7FFFB628ABEE (1 samples, 2.50%)</title><rect x="72.5000%" y="325" width="2.5000%" height="15" fill="rgb(235,182,43)" fg:x="29" fg:w="1"/><text x="72.7500%" y="335.50">`0..</text></g><g><title>`0x7FFFB628AE23 (1 samples, 2.50%)</title><rect x="72.5000%" y="309" width="2.5000%" height="15" fill="rgb(242,16,51)" fg:x="29" fg:w="1"/><text x="72.7500%" y="319.50">`0..</text></g><g><title>`0x7FFFB628B131 (1 samples, 2.50%)</title><rect x="72.5000%" y="293" width="2.5000%" height="15" fill="rgb(248,9,4)" fg:x="29" fg:w="1"/><text x="72.7500%" y="303.50">`0..</text></g><g><title>`0x7FFFB624FD52 (1 samples, 2.50%)</title><rect x="72.5000%" y="277" width="2.5000%" height="15" fill="rgb(210,31,22)" fg:x="29" fg:w="1"/><text x="72.7500%" y="287.50">`0..</text></g><g><title>`0x7FFFB8C56FB7 (1 samples, 2.50%)</title><rect x="72.5000%" y="261" width="2.5000%" height="15" fill="rgb(239,54,39)" fg:x="29" fg:w="1"/><text x="72.7500%" y="271.50">`0..</text></g><g><title>`0x7FFFB8BFE7B6 (1 samples, 2.50%)</title><rect x="72.5000%" y="245" width="2.5000%" height="15" fill="rgb(230,99,41)" fg:x="29" fg:w="1"/><text x="72.7500%" y="255.50">`0..</text></g><g><title>`0x7FFFB8C58B79 (1 samples, 2.50%)</title><rect x="75.0000%" y="629" width="2.5000%" height="15" fill="rgb(253,106,12)" fg:x="30" fg:w="1"/><text x="75.2500%" y="639.50">`0..</text></g><g><title>`0x7FFFB8BC77A0 (1 samples, 2.50%)</title><rect x="75.0000%" y="613" width="2.5000%" height="15" fill="rgb(213,46,41)" fg:x="30" fg:w="1"/><text x="75.2500%" y="623.50">`0..</text></g><g><title>`0x7FFFB8C0B77B (1 samples, 2.50%)</title><rect x="75.0000%" y="597" width="2.5000%" height="15" fill="rgb(215,133,35)" fg:x="30" fg:w="1"/><text x="75.2500%" y="607.50">`0..</text></g><g><title>`0x7FFFB8C0B94D (1 samples, 2.50%)</title><rect x="75.0000%" y="581" width="2.5000%" height="15" fill="rgb(213,28,5)" fg:x="30" fg:w="1"/><text x="75.2500%" y="591.50">`0..</text></g><g><title>`0x7FFFB8C0D98C (1 samples, 2.50%)</title><rect x="75.0000%" y="565" width="2.5000%" height="15" fill="rgb(215,77,49)" fg:x="30" fg:w="1"/><text x="75.2500%" y="575.50">`0..</text></g><g><title>`0x7FFFB8BFE7B3 (1 samples, 2.50%)</title><rect x="75.0000%" y="549" width="2.5000%" height="15" fill="rgb(248,100,22)" fg:x="30" fg:w="1"/><text x="75.2500%" y="559.50">`0..</text></g><g><title>`0x7FFFB8C7D6A5 (10 samples, 25.00%)</title><rect x="55.0000%" y="645" width="25.0000%" height="15" fill="rgb(208,67,9)" fg:x="22" fg:w="10"/><text x="55.2500%" y="655.50">`0x7FFFB8C7D6A5</text></g><g><title>`0x7FFFB8C58BA9 (1 samples, 2.50%)</title><rect x="77.5000%" y="629" width="2.5000%" height="15" fill="rgb(219,133,21)" fg:x="31" fg:w="1"/><text x="77.7500%" y="639.50">`0..</text></g><g><title>`0x7FFFB8BFF069 (1 samples, 2.50%)</title><rect x="77.5000%" y="613" width="2.5000%" height="15" fill="rgb(246,46,29)" fg:x="31" fg:w="1"/><text x="77.7500%" y="623.50">`0..</text></g><g><title>`0x7FFFB8D21F04 (1 samples, 2.50%)</title><rect x="77.5000%" y="597" width="2.5000%" height="15" fill="rgb(246,185,52)" fg:x="31" fg:w="1"/><text x="77.7500%" y="607.50">`0..</text></g><g><title>`0x7FFFB8C7D7AF (2 samples, 5.00%)</title><rect x="80.0000%" y="645" width="5.0000%" height="15" fill="rgb(252,136,11)" fg:x="32" fg:w="2"/><text x="80.2500%" y="655.50">`0x7FF..</text></g><g><title>`0x7FFFB8BD794E (2 samples, 5.00%)</title><rect x="80.0000%" y="629" width="5.0000%" height="15" fill="rgb(219,138,53)" fg:x="32" fg:w="2"/><text x="80.2500%" y="639.50">`0x7FF..</text></g><g><title>`0x7FFFB8BD977E (2 samples, 5.00%)</title><rect x="80.0000%" y="613" width="5.0000%" height="15" fill="rgb(211,51,23)" fg:x="32" fg:w="2"/><text x="80.2500%" y="623.50">`0x7FF..</text></g><g><title>`0x7FFFB8BC49F1 (2 samples, 5.00%)</title><rect x="80.0000%" y="597" width="5.0000%" height="15" fill="rgb(247,221,28)" fg:x="32" fg:w="2"/><text x="80.2500%" y="607.50">`0x7FF..</text></g><g><title>`0x7FFFB8BC4E1E (2 samples, 5.00%)</title><rect x="80.0000%" y="581" width="5.0000%" height="15" fill="rgb(251,222,45)" fg:x="32" fg:w="2"/><text x="80.2500%" y="591.50">`0x7FF..</text></g><g><title>`0x7FFFB8BC53DB (2 samples, 5.00%)</title><rect x="80.0000%" y="565" width="5.0000%" height="15" fill="rgb(217,162,53)" fg:x="32" fg:w="2"/><text x="80.2500%" y="575.50">`0x7FF..</text></g><g><title>`0x7FFFB8D221C4 (2 samples, 5.00%)</title><rect x="80.0000%" y="549" width="5.0000%" height="15" fill="rgb(229,93,14)" fg:x="32" fg:w="2"/><text x="80.2500%" y="559.50">`0x7FF..</text></g><g><title>`0x7FFFB8C7D7B7 (1 samples, 2.50%)</title><rect x="85.0000%" y="645" width="2.5000%" height="15" fill="rgb(209,67,49)" fg:x="34" fg:w="1"/><text x="85.2500%" y="655.50">`0..</text></g><g><title>`0x7FFFB8C4CF87 (1 samples, 2.50%)</title><rect x="85.0000%" y="629" width="2.5000%" height="15" fill="rgb(213,87,29)" fg:x="34" fg:w="1"/><text x="85.2500%" y="639.50">`0..</text></g><g><title>`0x7FFFB8C34281 (1 samples, 2.50%)</title><rect x="85.0000%" y="613" width="2.5000%" height="15" fill="rgb(205,151,52)" fg:x="34" fg:w="1"/><text x="85.2500%" y="623.50">`0..</text></g><g><title>`0x7FFFB8BFDA5F (1 samples, 2.50%)</title><rect x="85.0000%" y="597" width="2.5000%" height="15" fill="rgb(253,215,39)" fg:x="34" fg:w="1"/><text x="85.2500%" y="607.50">`0..</text></g><g><title>`0x7FFFB5D5382D (1 samples, 2.50%)</title><rect x="87.5000%" y="549" width="2.5000%" height="15" fill="rgb(221,220,41)" fg:x="35" fg:w="1"/><text x="87.7500%" y="559.50">`0..</text></g><g><title>`0x7FFFB5D53A51 (1 samples, 2.50%)</title><rect x="87.5000%" y="533" width="2.5000%" height="15" fill="rgb(218,133,21)" fg:x="35" fg:w="1"/><text x="87.7500%" y="543.50">`0..</text></g><g><title>`0x7FFFB8C1F222 (1 samples, 2.50%)</title><rect x="87.5000%" y="517" width="2.5000%" height="15" fill="rgb(221,193,43)" fg:x="35" fg:w="1"/><text x="87.7500%" y="527.50">`0..</text></g><g><title>`0x7FFFB8C1FCD1 (1 samples, 2.50%)</title><rect x="87.5000%" y="501" width="2.5000%" height="15" fill="rgb(240,128,52)" fg:x="35" fg:w="1"/><text x="87.7500%" y="511.50">`0..</text></g><g><title>`0x7FFFB8C20B82 (1 samples, 2.50%)</title><rect x="87.5000%" y="485" width="2.5000%" height="15" fill="rgb(253,114,12)" fg:x="35" fg:w="1"/><text x="87.7500%" y="495.50">`0..</text></g><g><title>`0x7FFFB8D25774 (1 samples, 2.50%)</title><rect x="87.5000%" y="469" width="2.5000%" height="15" fill="rgb(215,223,47)" fg:x="35" fg:w="1"/><text x="87.7500%" y="479.50">`0..</text></g><g><title>`0x7FFFB8C576EA (2 samples, 5.00%)</title><rect x="87.5000%" y="613" width="5.0000%" height="15" fill="rgb(248,225,23)" fg:x="35" fg:w="2"/><text x="87.7500%" y="623.50">`0x7FF..</text></g><g><title>`0x7FFFB8BC97AC (2 samples, 5.00%)</title><rect x="87.5000%" y="597" width="5.0000%" height="15" fill="rgb(250,108,0)" fg:x="35" fg:w="2"/><text x="87.7500%" y="607.50">`0x7FF..</text></g><g><title>`0x7FFFB8BCBCAE (2 samples, 5.00%)</title><rect x="87.5000%" y="581" width="5.0000%" height="15" fill="rgb(228,208,7)" fg:x="35" fg:w="2"/><text x="87.7500%" y="591.50">`0x7FF..</text></g><g><title>`0x7FFFB8D1F96E (2 samples, 5.00%)</title><rect x="87.5000%" y="565" width="5.0000%" height="15" fill="rgb(244,45,10)" fg:x="35" fg:w="2"/><text x="87.7500%" y="575.50">`0x7FF..</text></g><g><title>`0x7FFFB5D53832 (1 samples, 2.50%)</title><rect x="90.0000%" y="549" width="2.5000%" height="15" fill="rgb(207,125,25)" fg:x="36" fg:w="1"/><text x="90.2500%" y="559.50">`0..</text></g><g><title>`0x7FFFB5D53BB8 (1 samples, 2.50%)</title><rect x="90.0000%" y="533" width="2.5000%" height="15" fill="rgb(210,195,18)" fg:x="36" fg:w="1"/><text x="90.2500%" y="543.50">`0..</text></g><g><title>`0x7FFFB5D58307 (1 samples, 2.50%)</title><rect x="90.0000%" y="517" width="2.5000%" height="15" fill="rgb(249,80,12)" fg:x="36" fg:w="1"/><text x="90.2500%" y="527.50">`0..</text></g><g><title>`0x7FFFB622B9E0 (1 samples, 2.50%)</title><rect x="90.0000%" y="501" width="2.5000%" height="15" fill="rgb(221,65,9)" fg:x="36" fg:w="1"/><text x="90.2500%" y="511.50">`0..</text></g><g><title>`0x7FFFB6036E26 (1 samples, 2.50%)</title><rect x="92.5000%" y="533" width="2.5000%" height="15" fill="rgb(235,49,36)" fg:x="37" fg:w="1"/><text x="92.7500%" y="543.50">`0..</text></g><g><title>`0x7FFFB609AD56 (1 samples, 2.50%)</title><rect x="92.5000%" y="517" width="2.5000%" height="15" fill="rgb(225,32,20)" fg:x="37" fg:w="1"/><text x="92.7500%" y="527.50">`0..</text></g><g><title>`0x7FFFB602A776 (1 samples, 2.50%)</title><rect x="92.5000%" y="501" width="2.5000%" height="15" fill="rgb(215,141,46)" fg:x="37" fg:w="1"/><text x="92.7500%" y="511.50">`0..</text></g><g><title>`0x7FFFB602A906 (1 samples, 2.50%)</title><rect x="92.5000%" y="485" width="2.5000%" height="15" fill="rgb(250,160,47)" fg:x="37" fg:w="1"/><text x="92.7500%" y="495.50">`0..</text></g><g><title>`0x7FFFB602ABE7 (1 samples, 2.50%)</title><rect x="92.5000%" y="469" width="2.5000%" height="15" fill="rgb(216,222,40)" fg:x="37" fg:w="1"/><text x="92.7500%" y="479.50">`0..</text></g><g><title>`0x7FFFB602AAAC (1 samples, 2.50%)</title><rect x="92.5000%" y="453" width="2.5000%" height="15" fill="rgb(234,217,39)" fg:x="37" fg:w="1"/><text x="92.7500%" y="463.50">`0..</text></g><g><title>`0x7FFFB8C7B83A (22 samples, 55.00%)</title><rect x="42.5000%" y="677" width="55.0000%" height="15" fill="rgb(207,178,40)" fg:x="17" fg:w="22"/><text x="42.7500%" y="687.50">`0x7FFFB8C7B83A</text></g><g><title>`0x7FFFB8C7BA50 (22 samples, 55.00%)</title><rect x="42.5000%" y="661" width="55.0000%" height="15" fill="rgb(221,136,13)" fg:x="17" fg:w="22"/><text x="42.7500%" y="671.50">`0x7FFFB8C7BA50</text></g><g><title>`0x7FFFB8C7D8C6 (4 samples, 10.00%)</title><rect x="87.5000%" y="645" width="10.0000%" height="15" fill="rgb(249,199,10)" fg:x="35" fg:w="4"/><text x="87.7500%" y="655.50">`0x7FFFB8C7D8C6</text></g><g><title>`0x7FFFB8C57716 (4 samples, 10.00%)</title><rect x="87.5000%" y="629" width="10.0000%" height="15" fill="rgb(249,222,13)" fg:x="35" fg:w="4"/><text x="87.7500%" y="639.50">`0x7FFFB8C57716</text></g><g><title>`0x7FFFB8C57716 (2 samples, 5.00%)</title><rect x="92.5000%" y="613" width="5.0000%" height="15" fill="rgb(244,185,38)" fg:x="37" fg:w="2"/><text x="92.7500%" y="623.50">`0x7FF..</text></g><g><title>`0x7FFFB8C576EA (2 samples, 5.00%)</title><rect x="92.5000%" y="597" width="5.0000%" height="15" fill="rgb(236,202,9)" fg:x="37" fg:w="2"/><text x="92.7500%" y="607.50">`0x7FF..</text></g><g><title>`0x7FFFB8BC97AC (2 samples, 5.00%)</title><rect x="92.5000%" y="581" width="5.0000%" height="15" fill="rgb(250,229,37)" fg:x="37" fg:w="2"/><text x="92.7500%" y="591.50">`0x7FF..</text></g><g><title>`0x7FFFB8BCBCAE (2 samples, 5.00%)</title><rect x="92.5000%" y="565" width="5.0000%" height="15" fill="rgb(206,174,23)" fg:x="37" fg:w="2"/><text x="92.7500%" y="575.50">`0x7FF..</text></g><g><title>`0x7FFFB8D1F96E (2 samples, 5.00%)</title><rect x="92.5000%" y="549" width="5.0000%" height="15" fill="rgb(211,33,43)" fg:x="37" fg:w="2"/><text x="92.7500%" y="559.50">`0x7FF..</text></g><g><title>`0x7FFFB8092322 (1 samples, 2.50%)</title><rect x="95.0000%" y="533" width="2.5000%" height="15" fill="rgb(245,58,50)" fg:x="38" fg:w="1"/><text x="95.2500%" y="543.50">`0..</text></g><g><title>`0x7FFFB80923F5 (1 samples, 2.50%)</title><rect x="95.0000%" y="517" width="2.5000%" height="15" fill="rgb(244,68,36)" fg:x="38" fg:w="1"/><text x="95.2500%" y="527.50">`0..</text></g><g><title>`0x7FFFB809A000 (1 samples, 2.50%)</title><rect x="95.0000%" y="501" width="2.5000%" height="15" fill="rgb(232,229,15)" fg:x="38" fg:w="1"/><text x="95.2500%" y="511.50">`0..</text></g><g><title>all (40 samples, 100%)</title><rect x="0.0000%" y="709" width="100.0000%" height="15" fill="rgb(254,30,23)" fg:x="0" fg:w="40"/><text x="0.2500%" y="719.50"></text></g><g><title>`0x7FFFB8CA910E (23 samples, 57.50%)</title><rect x="42.5000%" y="693" width="57.5000%" height="15" fill="rgb(235,160,14)" fg:x="17" fg:w="23"/><text x="42.7500%" y="703.50">`0x7FFFB8CA910E</text></g><g><title>`0x7FFFB8CA914F (1 samples, 2.50%)</title><rect x="97.5000%" y="677" width="2.5000%" height="15" fill="rgb(212,155,44)" fg:x="39" fg:w="1"/><text x="97.7500%" y="687.50">`0..</text></g><g><title>`0x7FFFB8CA91D2 (1 samples, 2.50%)</title><rect x="97.5000%" y="661" width="2.5000%" height="15" fill="rgb(226,2,50)" fg:x="39" fg:w="1"/><text x="97.7500%" y="671.50">`0..</text></g><g><title>`0x7FFFB8BCDFED (1 samples, 2.50%)</title><rect x="97.5000%" y="645" width="2.5000%" height="15" fill="rgb(234,177,6)" fg:x="39" fg:w="1"/><text x="97.7500%" y="655.50">`0..</text></g><g><title>`0x7FFFB8BCF8EC (1 samples, 2.50%)</title><rect x="97.5000%" y="629" width="2.5000%" height="15" fill="rgb(217,24,9)" fg:x="39" fg:w="1"/><text x="97.7500%" y="639.50">`0..</text></g></svg></svg>

--- a/rust_chess/src/engine/minimax.rs
+++ b/rust_chess/src/engine/minimax.rs
@@ -78,18 +78,19 @@ impl Minimax {
         out
     }
 
-    pub fn find_best_move(&mut self, game: &mut Game, colour: Colour) -> Option<ChessMove> {
+    pub fn find_best_move(&mut self, game: &mut Game, colour: Colour, return_scores: bool) -> (Option<ChessMove>, Option<Vec<(ChessMove, i32)>>) {
         self.move_buffer.clear();
-
         Self::generate_and_order_moves(self, game, colour, 0);
 
         let mut best_move: Option<ChessMove> = None;
         let mut best_score: i32 = -INF;
+        let mut final_move_scores: Vec<(ChessMove, i32)> = Vec::new();  // To store scores at max depth
 
         // Loop for iterative deepening
         for depth in 1..=self.engine_options.max_depth {
             let mut current_best: Option<ChessMove> = None;
             let mut current_best_score = -INF;
+            let mut current_move_scores: Vec<(ChessMove, i32)> = Vec::new();  // Collect scores for this depth
 
             // PV move promotion
             if let Some(prev_best) = &best_move {
@@ -100,13 +101,13 @@ impl Minimax {
             }
 
             for i in (0..self.move_buffer.len()).rev() {
-                let mv = self.move_buffer[i]; 
+                let mv = self.move_buffer[i];
 
                 game.make_move(&mv);
-
                 let score = -self.minimax(game, depth - 1, -INF, INF, colour.other(), 1);
-
                 game.undo_last_move();
+
+                current_move_scores.push((mv, score));
 
                 if score > current_best_score {
                     current_best_score = score;
@@ -118,37 +119,28 @@ impl Minimax {
                 best_move = Some(mv);
                 best_score = current_best_score;
             }
+
+            // At max depth, store and print the sorted scores
+            if depth == self.engine_options.max_depth {
+                final_move_scores = current_move_scores;
+                final_move_scores.sort_by(|a, b| b.1.cmp(&a.1));  // Sort descending by score
+                println!("Moves with scores at depth {}:", depth);
+                for (mv, score) in &final_move_scores {
+                    println!("{}: {}", mv, score);
+                }
+            }
         }
 
-        best_move
-    }
-    // Does not use iterative deepening
-    // Should be used for move ordering/evaluation and sanity checks. Not for actual move selection.
-    pub fn find_sorted_moves(&mut self, game: &mut Game, colour: Colour) -> Vec<(ChessMove, i32)> {
-        self.move_buffer.clear();
-
-        Self::generate_and_order_moves(self, game, colour, 0);
-
-        let mut move_scores: Vec<(ChessMove, i32)> = Vec::new();
-
-        // Use the configured max depth
-        let depth = self.engine_options.max_depth;
-
-        while let Some(mv) = self.move_buffer.pop()  {
-            game.make_move(&mv);
-
-            // Recurse with minimax at ply 1
-            let score = -self.minimax(game, depth - 1, -INF, INF, colour.other(), 1);
-
-            game.undo_last_move();
-
-            move_scores.push((mv, score));
+        if return_scores {
+            // At max depth, return final_move_scores instead of printing
+            (best_move, Some(final_move_scores))
+        } else {
+            println!("Moves with scores at depth {}:", self.engine_options.max_depth);
+            for (mv, score) in &final_move_scores {
+                println!("{}: {}", mv, score);
+            }
+            (best_move, None)
         }
-
-        // Sort descending by score
-        move_scores.sort_by(|a, b| b.1.cmp(&a.1));
-
-        move_scores
     }
 
     // Helper: Probe the TT for a usable entry
@@ -387,7 +379,7 @@ mod tests {
         let mut game = starting_game();
         let mut engine = Minimax::new(1, 1, false, false);
 
-        let best_move = engine.find_best_move(&mut game, Colour::White);
+        let (best_move, _) = engine.find_best_move(&mut game, Colour::White, false);
 
         assert!(best_move.is_some(), "Best move should not be None");
 
@@ -467,7 +459,6 @@ mod tests {
         assert!(eval < 0, "Evaluation should indicate checkmate loss for White");
     }
 
-
     #[test]
     fn test_black_gets_checkmated() {
         let mut game = Game::new();
@@ -499,7 +490,8 @@ mod tests {
 
 
         let to_move = game.get_game_state().get_turn();
-        let moves = engine.find_sorted_moves(&mut game, to_move);
+        let (_, scores_opt) = engine.find_best_move(&mut game, to_move, true);
+        let moves = scores_opt.unwrap();
 
         // Ensure there is at least one move
         assert!(!moves.is_empty(), "There should be at least one legal move for White");
@@ -520,7 +512,6 @@ mod tests {
         for w in moves.windows(2) {
             assert!(w[0].1 >= w[1].1, "Moves are not sorted by descending evaluation");
         }
-
     }
 
     #[test]
@@ -559,9 +550,9 @@ mod tests {
         game.make_move(&d2_d4);
         game.make_move(&g7_g5);
 
-
         let to_move = game.get_game_state().get_turn();
-        let moves = engine.find_sorted_moves(&mut game, to_move);
+        let (_, scores_opt) = engine.find_best_move(&mut game, to_move, true);
+        let moves = scores_opt.unwrap();
 
         // Ensure there is at least one move
         assert!(!moves.is_empty(), "There should be at least one legal move for White");
@@ -582,7 +573,6 @@ mod tests {
         for w in moves.windows(2) {
             assert!(w[0].1 >= w[1].1, "Moves are not sorted by descending evaluation");
         }
-
     }
 
     #[test]

--- a/rust_chess/src/engine/minimax.rs
+++ b/rust_chess/src/engine/minimax.rs
@@ -104,10 +104,11 @@ impl Minimax {
                 }
             }
 
-            for mv in self.move_buffer.clone() {
+            for i in (0..self.move_buffer.len()).rev() {
+                let mv = self.move_buffer[i]; 
+
                 game.make_move(&mv);
 
-                // recurse: pass ply = 1 for child
                 let score = -self.minimax(game, depth - 1, -INF, INF, colour.other(), 1);
 
                 game.undo_last_move();

--- a/rust_chess/src/engine/minimax.rs
+++ b/rust_chess/src/engine/minimax.rs
@@ -136,10 +136,6 @@ impl Minimax {
             // At max depth, return final_move_scores instead of printing
             (best_move, Some(final_move_scores))
         } else {
-            println!("Moves with scores at depth {}:", self.engine_options.max_depth);
-            for (mv, score) in &final_move_scores {
-                println!("{}: {}", mv, score);
-            }
             (best_move, None)
         }
     }

--- a/rust_chess/src/engine/minimax.rs
+++ b/rust_chess/src/engine/minimax.rs
@@ -78,18 +78,19 @@ impl Minimax {
         out
     }
 
-    pub fn find_best_move(&mut self, game: &mut Game, colour: Colour) -> Option<ChessMove> {
+    pub fn find_best_move(&mut self, game: &mut Game, colour: Colour, return_scores: bool) -> (Option<ChessMove>, Option<Vec<(ChessMove, i32)>>) {
         self.move_buffer.clear();
-
         Self::generate_and_order_moves(self, game, colour, 0);
 
         let mut best_move: Option<ChessMove> = None;
         let mut best_score: i32 = -INF;
+        let mut final_move_scores: Vec<(ChessMove, i32)> = Vec::new();  // To store scores at max depth
 
         // Loop for iterative deepening
         for depth in 1..=self.engine_options.max_depth {
             let mut current_best: Option<ChessMove> = None;
             let mut current_best_score = -INF;
+            let mut current_move_scores: Vec<(ChessMove, i32)> = Vec::new();  // Collect scores for this depth
 
             // PV move promotion
             if let Some(prev_best) = &best_move {
@@ -100,13 +101,13 @@ impl Minimax {
             }
 
             for i in (0..self.move_buffer.len()).rev() {
-                let mv = self.move_buffer[i]; 
+                let mv = self.move_buffer[i];
 
                 game.make_move(&mv);
-
                 let score = -self.minimax(game, depth - 1, -INF, INF, colour.other(), 1);
-
                 game.undo_last_move();
+
+                current_move_scores.push((mv, score));
 
                 if score > current_best_score {
                     current_best_score = score;
@@ -118,37 +119,28 @@ impl Minimax {
                 best_move = Some(mv);
                 best_score = current_best_score;
             }
+
+            // At max depth, store and print the sorted scores
+            if depth == self.engine_options.max_depth {
+                final_move_scores = current_move_scores;
+                final_move_scores.sort_by(|a, b| b.1.cmp(&a.1));  // Sort descending by score
+                println!("Moves with scores at depth {}:", depth);
+                for (mv, score) in &final_move_scores {
+                    println!("{}: {}", mv, score);
+                }
+            }
         }
 
-        best_move
-    }
-    // Does not use iterative deepening
-    // Should be used for move ordering/evaluation and sanity checks. Not for actual move selection.
-    pub fn find_sorted_moves(&mut self, game: &mut Game, colour: Colour) -> Vec<(ChessMove, i32)> {
-        self.move_buffer.clear();
-
-        Self::generate_and_order_moves(self, game, colour, 0);
-
-        let mut move_scores: Vec<(ChessMove, i32)> = Vec::new();
-
-        // Use the configured max depth
-        let depth = self.engine_options.max_depth;
-
-        while let Some(mv) = self.move_buffer.pop()  {
-            game.make_move(&mv);
-
-            // Recurse with minimax at ply 1
-            let score = -self.minimax(game, depth - 1, -INF, INF, colour.other(), 1);
-
-            game.undo_last_move();
-
-            move_scores.push((mv, score));
+        if return_scores {
+            // At max depth, return final_move_scores instead of printing
+            (best_move, Some(final_move_scores))
+        } else {
+            println!("Moves with scores at depth {}:", self.engine_options.max_depth);
+            for (mv, score) in &final_move_scores {
+                println!("{}: {}", mv, score);
+            }
+            (best_move, None)
         }
-
-        // Sort descending by score
-        move_scores.sort_by(|a, b| b.1.cmp(&a.1));
-
-        move_scores
     }
 
     // Helper: Probe the TT for a usable entry
@@ -194,7 +186,17 @@ impl Minimax {
         }
     }
 
-    // minimax now takes an explicit depth_level parameter so each level uses its own buffers
+    // Helper to generate and order moves starting from a given index in move_buffer
+    fn generate_and_order_moves(&mut self, game: &mut Game, colour: Colour, start_index: usize) {
+        MoveGenerator::generate_legal_moves_into(
+            game,
+            colour,
+            self.engine_options.magic_bitboards,
+            &mut self.move_buffer,
+        );
+        order_moves(&mut self.move_buffer[start_index..], game);
+    }
+
     fn minimax(&mut self, game: &mut Game, depth: usize, mut alpha: i32, mut beta: i32, colour: Colour, depth_level: usize) -> i32 {
         self.nodes += 1;
         let hash = game.get_current_hash();
@@ -224,7 +226,6 @@ impl Minimax {
             let mv = self.move_buffer.pop().unwrap();
             game.make_move(&mv);
 
-            // recursive call will generate into move_buffers[ply + 1]
             let score = -self.minimax(game, depth - 1, -beta, -alpha, colour.other(), depth_level + 1);
 
             game.undo_last_move();
@@ -319,17 +320,6 @@ impl Minimax {
 
         best_score
     }
-
-    // Helper to generate and order moves starting from a given index in move_buffer
-    fn generate_and_order_moves(&mut self, game: &mut Game, colour: Colour, start_index: usize) {
-        MoveGenerator::generate_legal_moves_into(
-            game,
-            colour,
-            self.engine_options.magic_bitboards,
-            &mut self.move_buffer,
-        );
-        order_moves(&mut self.move_buffer[start_index..], game);
-    }
 }
 
 #[cfg(test)]
@@ -387,7 +377,7 @@ mod tests {
         let mut game = starting_game();
         let mut engine = Minimax::new(1, 1, false, false);
 
-        let best_move = engine.find_best_move(&mut game, Colour::White);
+        let (best_move, _) = engine.find_best_move(&mut game, Colour::White, false);
 
         assert!(best_move.is_some(), "Best move should not be None");
 
@@ -467,7 +457,6 @@ mod tests {
         assert!(eval < 0, "Evaluation should indicate checkmate loss for White");
     }
 
-
     #[test]
     fn test_black_gets_checkmated() {
         let mut game = Game::new();
@@ -499,7 +488,8 @@ mod tests {
 
 
         let to_move = game.get_game_state().get_turn();
-        let moves = engine.find_sorted_moves(&mut game, to_move);
+        let (_, scores_opt) = engine.find_best_move(&mut game, to_move, true);
+        let moves = scores_opt.unwrap();
 
         // Ensure there is at least one move
         assert!(!moves.is_empty(), "There should be at least one legal move for White");
@@ -520,7 +510,6 @@ mod tests {
         for w in moves.windows(2) {
             assert!(w[0].1 >= w[1].1, "Moves are not sorted by descending evaluation");
         }
-
     }
 
     #[test]
@@ -559,9 +548,9 @@ mod tests {
         game.make_move(&d2_d4);
         game.make_move(&g7_g5);
 
-
         let to_move = game.get_game_state().get_turn();
-        let moves = engine.find_sorted_moves(&mut game, to_move);
+        let (_, scores_opt) = engine.find_best_move(&mut game, to_move, true);
+        let moves = scores_opt.unwrap();
 
         // Ensure there is at least one move
         assert!(!moves.is_empty(), "There should be at least one legal move for White");
@@ -582,7 +571,6 @@ mod tests {
         for w in moves.windows(2) {
             assert!(w[0].1 >= w[1].1, "Moves are not sorted by descending evaluation");
         }
-
     }
 
     #[test]

--- a/rust_chess/src/engine/minimax.rs
+++ b/rust_chess/src/engine/minimax.rs
@@ -8,6 +8,7 @@ use crate::move_ordering::order_moves;
 use crate::engine::evaluator::Evaluator;
 
 pub const INF: i32 = 30_000;
+pub const MAX_MOVES: usize = 2048;
 
 #[derive(Clone, Copy)]
 pub enum Bound {
@@ -39,10 +40,7 @@ pub struct Minimax {
     pub nodes: usize,
     pub tt_hits: usize,
 
-    // move buffers: one Vec<ChessMove> per ply (0..=max_depth)
-    pub move_buffers: Vec<Vec<ChessMove>>,
-    // tactical buffers for quiescence (captures/promotions) per ply
-    pub tactical_buffers: Vec<Vec<ChessMove>>,
+    pub move_buffer: Vec<ChessMove>,
 }
 
 impl Minimax {
@@ -57,26 +55,13 @@ impl Minimax {
             magic_bitboards: magic_bitboard,
         };
 
-        // preallocate per-ply buffers: need max_depth + 2 to be safe (root + depths)
-        let buffer_count = max_depth + 2;
-        let mut move_buffers = Vec::with_capacity(buffer_count);
-        for _ in 0..buffer_count {
-            move_buffers.push(Vec::with_capacity(256));     // ~MAX_MOVES
-        }
-
-        let tact_buffer_count = quiescence_max_depth + 2;
-        let mut tactical_buffers = Vec::with_capacity(tact_buffer_count);
-        for _ in 0..tact_buffer_count {
-            tactical_buffers.push(Vec::with_capacity(64));  // fewer tactical moves typically
-        }
-
+        let move_buffer = Vec::with_capacity(MAX_MOVES);
         Self {
             engine_options: options,
             tt: HashMap::new(),
             nodes: 0,
             tt_hits: 0,
-            move_buffers,
-            tactical_buffers,
+            move_buffer,
         }
     }
 
@@ -84,17 +69,14 @@ impl Minimax {
         game.make_move(mv);
         let to_move = game.get_game_state().get_turn();
 
-        // use ply 0 buffer for this temporary generation
-        let ply = 0;
-        self.move_buffers[ply].clear();
         MoveGenerator::generate_legal_moves_into(
             game,
             to_move,
             self.engine_options.magic_bitboards,
-            &mut self.move_buffers[ply],
+            &mut self.move_buffer,
         );
 
-        let game_result = game.is_game_over_with_moves(&self.move_buffers[ply], self.engine_options.magic_bitboards);
+        let game_result = game.is_game_over_with_moves(&self.move_buffer, self.engine_options.magic_bitboards);
         let out = Evaluator::evaluate_game_result(game, game_result, 0, to_move);
 
         game.undo_last_move();
@@ -105,33 +87,29 @@ impl Minimax {
         let mut best_move: Option<ChessMove> = None;
         let mut best_score: i32 = -INF;
 
+        self.move_buffer.clear();
+        MoveGenerator::generate_legal_moves_into(
+            game,
+            colour,
+            self.engine_options.magic_bitboards,
+            &mut self.move_buffer,
+        );
+        order_moves(&mut self.move_buffer[..], game);
+
         for depth in 1..=self.engine_options.max_depth {
             let mut current_best: Option<ChessMove> = None;
             let mut current_best_score = -INF;
 
-            // root is ply 0
-            let root_ply = 0;
-            self.move_buffers[root_ply].clear();
-            MoveGenerator::generate_legal_moves_into(
-                game,
-                colour,
-                self.engine_options.magic_bitboards,
-                &mut self.move_buffers[root_ply],
-            );
-            order_moves(&mut self.move_buffers[root_ply], game);
 
             // PV move promotion
             if let Some(prev_best) = &best_move {
-                if let Some(idx) = self.move_buffers[root_ply].iter().position(|m| m == prev_best) {
-                    let mv = self.move_buffers[root_ply].remove(idx);
-                    self.move_buffers[root_ply].insert(0, mv);
+                if let Some(idx) = self.move_buffer.iter().position(|m| m == prev_best) {
+                    let mv = self.move_buffer.remove(idx);
+                    self.move_buffer.push(mv);
                 }
             }
 
-            let len = self.move_buffers[root_ply].len();
-            for i in 0..len {
-                // clone the move out (requires ChessMove: Clone)
-                let mv = self.move_buffers[root_ply][i].clone();
+            for mv in self.move_buffer.clone() {
                 game.make_move(&mv);
 
                 // recurse: pass ply = 1 for child
@@ -159,20 +137,16 @@ impl Minimax {
         // Use the configured max depth
         let depth = self.engine_options.max_depth;
 
-        // root is ply 0
-        let root_ply = 0;
-        self.move_buffers[root_ply].clear();
+        self.move_buffer.clear();
         MoveGenerator::generate_legal_moves_into(
             game,
             colour,
             self.engine_options.magic_bitboards,
-            &mut self.move_buffers[root_ply],
+            &mut self.move_buffer,
         );
-        order_moves(&mut self.move_buffers[root_ply], game);
+        order_moves(&mut self.move_buffer, game);
 
-        let len = self.move_buffers[root_ply].len();
-        for i in 0..len {
-            let mv = self.move_buffers[root_ply][i].clone();
+        while let Some(mv) = self.move_buffer.pop()  {
             game.make_move(&mv);
 
             // Recurse with minimax at ply 1
@@ -210,30 +184,32 @@ impl Minimax {
             }
         }
 
+        let move_start_index = self.move_buffer.len();
+
         // generate moves into buffer for this ply
-        self.move_buffers[ply].clear();
         MoveGenerator::generate_legal_moves_into(
             game,
             colour,
             self.engine_options.magic_bitboards,
-            &mut self.move_buffers[ply],
+            &mut self.move_buffer,
         );
-        order_moves(&mut self.move_buffers[ply], game);
+        order_moves(&mut self.move_buffer[move_start_index..], game);
 
-        if let Some(result) = game.is_game_over_with_moves(&self.move_buffers[ply], self.engine_options.magic_bitboards) {
+        if let Some(result) = game.is_game_over_with_moves(&self.move_buffer[move_start_index..], self.engine_options.magic_bitboards) {
+            self.move_buffer.truncate(move_start_index);
             return Evaluator::evaluate_game_result(game, Some(result), ply, colour);
         }
 
         if depth == 0 {
+            self.move_buffer.truncate(move_start_index);
             return self.quiescence(game, alpha, beta, self.engine_options.quiescence_max_depth, 0);
         }
 
         let orig_alpha = alpha;
         let mut best_score = -INF;
 
-        let len = self.move_buffers[ply].len();
-        for i in 0..len {
-            let mv = self.move_buffers[ply][i].clone();
+        while self.move_buffer.len() > move_start_index {
+            let mv = self.move_buffer.pop().unwrap();
             game.make_move(&mv);
 
             // recursive call will generate into move_buffers[ply + 1]
@@ -282,6 +258,7 @@ impl Minimax {
             }
         }
 
+        self.move_buffer.truncate(move_start_index);
         best_score
     }
 
@@ -316,7 +293,6 @@ impl Minimax {
         let to_move = game.get_game_state().get_turn();
         let escape_check = game.is_player_in_check(to_move, self.engine_options.magic_bitboards);
 
-
         // stand pat
         let stand_pat = Evaluator::evaluate_game_result(game, None, ply, to_move);
         if max_depth == 0 || (!escape_check && stand_pat >= beta) {
@@ -326,26 +302,24 @@ impl Minimax {
             alpha = stand_pat;
         }
 
+        let move_start_index = self.move_buffer.len();
         // generate only tactical moves into the tactical buffer for this ply
-        self.tactical_buffers[ply].clear();
         MoveGenerator::generate_legal_moves_into(
             game,
             to_move,
             self.engine_options.magic_bitboards,
-            &mut self.tactical_buffers[ply],
+            &mut self.move_buffer,
         );
-        order_moves(&mut self.tactical_buffers[ply], game);
-
-        if let Some(result) = game.is_game_over_with_moves(&self.tactical_buffers[ply], self.engine_options.magic_bitboards) {
+        order_moves(&mut self.move_buffer[move_start_index..], game);
+        if let Some(result) = game.is_game_over_with_moves(&self.move_buffer[move_start_index..], self.engine_options.magic_bitboards) {
+            self.move_buffer.truncate(move_start_index);
             return Evaluator::evaluate_game_result(game, Some(result), ply, to_move);
         }
 
         let mut best_score = if !escape_check {stand_pat} else {-INF};
-        let len = self.tactical_buffers[ply].len();
 
-
-        for i in 0..len {
-            let mv = self.tactical_buffers[ply][i].clone();
+        while self.move_buffer.len() > move_start_index {
+            let mv = self.move_buffer.pop().unwrap();
             if !escape_check && !MoveGenerator::is_tactical_move(game, &mv, self.engine_options.magic_bitboards) {
                 continue
             }
@@ -354,6 +328,7 @@ impl Minimax {
             game.undo_last_move();
 
             if score >= beta {
+                self.move_buffer.truncate(move_start_index);
                 return score;
             }
             if score > best_score {
@@ -392,6 +367,8 @@ impl Minimax {
 
 #[cfg(test)]
 mod tests {
+    use std::vec;
+
     use super::*;
     use crate::coords::Coords;
     use crate::enums::moves::NormalMove;
@@ -409,16 +386,15 @@ mod tests {
         let mut engine = Minimax::new(3, 6, true, true);
 
         // Generate legal moves at the root
-        engine.move_buffers[0].clear();
         MoveGenerator::generate_legal_moves_into(
             &mut game,
             Colour::White,
             false,
-            &mut engine.move_buffers[0],
+            &mut engine.move_buffer,
         );
 
         // Pick the first move to evaluate
-        let mv = engine.move_buffers[0][0].clone();
+        let mv = engine.move_buffer[0].clone();
         let eval = engine.evaluate_move(&mut game, &mv);
 
         // Evaluation should be within reasonable bounds for starting position
@@ -450,14 +426,14 @@ mod tests {
 
         // Make sure the move is legal
         let mv = best_move.unwrap();
-        engine.move_buffers[0].clear();
+        let mut legal_moves = vec![];
         MoveGenerator::generate_legal_moves_into(
             &mut game,
             Colour::White,
             false,
-            &mut engine.move_buffers[0],
+            &mut legal_moves,
         );
-        assert!(engine.move_buffers[0].contains(&mv), "Best move is not legal");
+        assert!(legal_moves.contains(&mv), "Best move is not legal");
     }
 
     #[test]
@@ -466,14 +442,14 @@ mod tests {
         let mut engine = Minimax::new(1, 1, false, false);
 
         // Pick one move from root and evaluate using minimax
-        engine.move_buffers[0].clear();
+        engine.move_buffer.clear();
         MoveGenerator::generate_legal_moves_into(
             &mut game,
             Colour::White,
             false,
-            &mut engine.move_buffers[0],
+            &mut engine.move_buffer,
         );
-        let mv = engine.move_buffers[0][0].clone();
+        let mv = engine.move_buffer[0].clone();
 
         game.make_move(&mv);
         let score = -engine.minimax(&mut game, 0, -INF, INF, Colour::Black, 1);

--- a/rust_chess/src/engine/minimax.rs
+++ b/rust_chess/src/engine/minimax.rs
@@ -1,4 +1,3 @@
-use std::any::Any;
 use std::collections::HashMap;
 
 use crate::game_classes::game::Game;
@@ -69,14 +68,10 @@ impl Minimax {
         game.make_move(mv);
         let to_move = game.get_game_state().get_turn();
 
-        MoveGenerator::generate_legal_moves_into(
-            game,
-            to_move,
-            self.engine_options.magic_bitboards,
-            &mut self.move_buffer,
-        );
+        let move_start_index = self.move_buffer.len();
+        Self::generate_and_order_moves(self, game, to_move, move_start_index);
 
-        let game_result = game.is_game_over_with_moves(&self.move_buffer, self.engine_options.magic_bitboards);
+        let game_result = game.is_game_over_with_moves(&self.move_buffer[move_start_index..], self.engine_options.magic_bitboards);
         let out = Evaluator::evaluate_game_result(game, game_result, 0, to_move);
 
         game.undo_last_move();
@@ -84,22 +79,22 @@ impl Minimax {
     }
 
     pub fn find_best_move(&mut self, game: &mut Game, colour: Colour) -> Option<ChessMove> {
-        let mut best_move: Option<ChessMove> = None;
-        let mut best_score: i32 = -INF;
-
         self.move_buffer.clear();
 
         Self::generate_and_order_moves(self, game, colour, 0);
 
+        let mut best_move: Option<ChessMove> = None;
+        let mut best_score: i32 = -INF;
+
+        // Loop for iterative deepening
         for depth in 1..=self.engine_options.max_depth {
             let mut current_best: Option<ChessMove> = None;
             let mut current_best_score = -INF;
 
-
             // PV move promotion
             if let Some(prev_best) = &best_move {
                 if let Some(idx) = self.move_buffer.iter().position(|m| m == prev_best) {
-                    let mv = self.move_buffer.remove(idx);
+                    let mv = self.move_buffer.swap_remove(idx);
                     self.move_buffer.push(mv);
                 }
             }
@@ -127,14 +122,17 @@ impl Minimax {
 
         best_move
     }
+    // Does not use iterative deepening
+    // Should be used for move ordering/evaluation and sanity checks. Not for actual move selection.
     pub fn find_sorted_moves(&mut self, game: &mut Game, colour: Colour) -> Vec<(ChessMove, i32)> {
+        self.move_buffer.clear();
+
+        Self::generate_and_order_moves(self, game, colour, 0);
+
         let mut move_scores: Vec<(ChessMove, i32)> = Vec::new();
 
         // Use the configured max depth
         let depth = self.engine_options.max_depth;
-
-        self.move_buffer.clear();
-        Self::generate_and_order_moves(self, game, colour, 0);
 
         while let Some(mv) = self.move_buffer.pop()  {
             game.make_move(&mv);
@@ -153,34 +151,65 @@ impl Minimax {
         move_scores
     }
 
-    // minimax now takes an explicit ply parameter so each level uses its own buffers
-    fn minimax(&mut self, game: &mut Game, depth: usize, mut alpha: i32, mut beta: i32, colour: Colour, ply: usize) -> i32 {
-        self.nodes += 1;
-        let hash = game.get_current_hash();
-
-        if self.engine_options.use_transposition_tables {
-            if let Some(entry) = self.tt.get(&hash) {
-                if !entry.is_quiescence && entry.depth >= depth {
-                    self.tt_hits += 1;
-                    match entry.bound {
-                        Bound::Exact => return entry.value,
-                        Bound::Lower => alpha = alpha.max(entry.value),
-                        Bound::Upper => beta = beta.min(entry.value),
-                    }
-                    if alpha >= beta {
-                        return entry.value;
-                    }
+    // Helper: Probe the TT for a usable entry
+    fn tt_lookup(&mut self, hash: u64, depth: usize, is_quiescence: bool, alpha: &mut i32, beta: &mut i32) -> Option<i32> {
+        if !self.engine_options.use_transposition_tables {
+            return None;
+        }
+        if let Some(entry) = self.tt.get(&hash) {
+            if (!entry.is_quiescence && !is_quiescence && entry.depth >= depth)
+                || (entry.is_quiescence && is_quiescence && entry.depth >= depth) {
+                self.tt_hits += 1;
+                match entry.bound {
+                    Bound::Exact => return Some(entry.value),
+                    Bound::Lower => *alpha = (*alpha).max(entry.value),
+                    Bound::Upper => *beta = (*beta).min(entry.value),
+                }
+                if *alpha >= *beta {
+                    return Some(entry.value);
                 }
             }
         }
+        None
+    }
+
+    // Helper: Store a new entry in the TT with replacement logic
+    fn tt_store(&mut self, hash: u64, depth: usize, value: i32, bound: Bound, is_quiescence: bool) {
+        if !self.engine_options.use_transposition_tables {
+            return;
+        }
+        let new_entry = TTEntry { depth, value, bound, is_quiescence };
+        match self.tt.get(&hash) {
+            Some(existing) => {
+                let should_replace = (!existing.is_quiescence && !is_quiescence && new_entry.depth >= existing.depth)
+                    || (existing.is_quiescence && is_quiescence && new_entry.depth >= existing.depth)
+                    || (!existing.is_quiescence && is_quiescence);
+                if should_replace {
+                    self.tt.insert(hash, new_entry);
+                }
+            }
+            None => {
+                self.tt.insert(hash, new_entry);
+            }
+        }
+    }
+
+    // minimax now takes an explicit depth_level parameter so each level uses its own buffers
+    fn minimax(&mut self, game: &mut Game, depth: usize, mut alpha: i32, mut beta: i32, colour: Colour, depth_level: usize) -> i32 {
+        self.nodes += 1;
+        let hash = game.get_current_hash();
+
+        // TT lookup
+        if let Some(tt_value) = self.tt_lookup(hash, depth, false, &mut alpha, &mut beta) {
+            return tt_value;
+        }
 
         let move_start_index = self.move_buffer.len();
-
         Self::generate_and_order_moves(self, game, colour, move_start_index);
 
         if let Some(result) = game.is_game_over_with_moves(&self.move_buffer[move_start_index..], self.engine_options.magic_bitboards) {
             self.move_buffer.truncate(move_start_index);
-            return Evaluator::evaluate_game_result(game, Some(result), ply, colour);
+            return Evaluator::evaluate_game_result(game, Some(result), depth_level, colour);
         }
 
         if depth == 0 {
@@ -196,7 +225,7 @@ impl Minimax {
             game.make_move(&mv);
 
             // recursive call will generate into move_buffers[ply + 1]
-            let score = -self.minimax(game, depth - 1, -beta, -alpha, colour.other(), ply+1);
+            let score = -self.minimax(game, depth - 1, -beta, -alpha, colour.other(), depth_level + 1);
 
             game.undo_last_move();
 
@@ -211,73 +240,34 @@ impl Minimax {
             }
         }
 
-        if self.engine_options.use_transposition_tables {
-            let bound = if best_score <= orig_alpha {
-                Bound::Upper
-            } else if best_score >= beta {
-                Bound::Lower
-            } else {
-                Bound::Exact
-            };
-
-            let new_entry = TTEntry {
-                depth,
-                value: best_score,
-                bound,
-                is_quiescence: false,
-            };
-
-            match self.tt.get(&hash) {
-                Some(existing) => {
-                    let should_replace = (!existing.is_quiescence && new_entry.depth >= existing.depth)
-                        || (existing.is_quiescence && !new_entry.is_quiescence);
-                    if should_replace {
-                        self.tt.insert(hash, new_entry);
-                    }
-                }
-                None => {
-                    self.tt.insert(hash, new_entry);
-                }
-            }
-        }
+        // TT store
+        let bound = if best_score <= orig_alpha {
+            Bound::Upper
+        } else if best_score >= beta {
+            Bound::Lower
+        } else {
+            Bound::Exact
+        };
+        self.tt_store(hash, depth, best_score, bound, false);
 
         self.move_buffer.truncate(move_start_index);
         best_score
     }
 
-    // quiescence uses the tactical buffer for this ply
-    fn quiescence(
-        &mut self,
-        game: &mut Game,
-        mut alpha: i32,
-        mut beta: i32,
-        max_depth: usize,
-        ply: usize,
-    ) -> i32 {
+    fn quiescence(&mut self, game: &mut Game, mut alpha: i32, mut beta: i32, max_depth: usize, depth_level: usize) -> i32 {
         self.nodes += 1;
         let hash = game.get_current_hash();
 
-        if self.engine_options.use_transposition_tables {
-            if let Some(entry) = self.tt.get(&hash) {
-                if entry.is_quiescence && entry.depth >= max_depth {
-                    self.tt_hits += 1;
-                    match entry.bound {
-                        Bound::Exact => return entry.value,
-                        Bound::Lower => alpha = alpha.max(entry.value),
-                        Bound::Upper => beta = beta.min(entry.value),
-                    }
-                    if alpha >= beta {
-                        return entry.value;
-                    }
-                }
-            }
+        // TT lookup
+        if let Some(tt_value) = self.tt_lookup(hash, max_depth, true, &mut alpha, &mut beta) {
+            return tt_value;
         }
 
         let to_move = game.get_game_state().get_turn();
         let escape_check = game.is_player_in_check(to_move, self.engine_options.magic_bitboards);
 
         // stand pat
-        let stand_pat = Evaluator::evaluate_game_result(game, None, ply, to_move);
+        let stand_pat = Evaluator::evaluate_game_result(game, None, depth_level, to_move);
         if max_depth == 0 || (!escape_check && stand_pat >= beta) {
             return stand_pat;
         }
@@ -290,9 +280,10 @@ impl Minimax {
 
         if let Some(result) = game.is_game_over_with_moves(&self.move_buffer[move_start_index..], self.engine_options.magic_bitboards) {
             self.move_buffer.truncate(move_start_index);
-            return Evaluator::evaluate_game_result(game, Some(result), ply, to_move);
+            return Evaluator::evaluate_game_result(game, Some(result), depth_level, to_move);
         }
 
+        let orig_alpha = alpha;
         let mut best_score = if !escape_check {stand_pat} else {-INF};
 
         while self.move_buffer.len() > move_start_index {
@@ -301,7 +292,7 @@ impl Minimax {
                 continue
             }
             game.make_move(&mv);
-            let score = -self.quiescence(game, -beta, -alpha, max_depth - 1, ply + 1);
+            let score = -self.quiescence(game, -beta, -alpha, max_depth - 1, depth_level + 1);
             game.undo_last_move();
 
             if score >= beta {
@@ -316,27 +307,15 @@ impl Minimax {
             }
         }
 
-        // store quiescence result if using TT (same logic as before)
-        if self.engine_options.use_transposition_tables {
-            let new_entry = TTEntry {
-                depth: max_depth,
-                value: best_score,
-                bound: Bound::Exact,
-                is_quiescence: true,
-            };
-            match self.tt.get(&hash) {
-                Some(existing) => {
-                    let should_replace = (existing.is_quiescence && new_entry.depth >= existing.depth)
-                        || (!existing.is_quiescence);
-                    if should_replace {
-                        self.tt.insert(hash, new_entry);
-                    }
-                }
-                None => {
-                    self.tt.insert(hash, new_entry);
-                }
-            }
-        }
+        // TT store
+        let bound = if best_score <= orig_alpha {
+            Bound::Upper
+        } else if best_score >= beta {
+            Bound::Lower
+        } else {
+            Bound::Exact
+        };
+        self.tt_store(hash, max_depth, best_score, bound, true);
 
         best_score
     }

--- a/rust_chess/src/engine/minimax.rs
+++ b/rust_chess/src/engine/minimax.rs
@@ -88,13 +88,8 @@ impl Minimax {
         let mut best_score: i32 = -INF;
 
         self.move_buffer.clear();
-        MoveGenerator::generate_legal_moves_into(
-            game,
-            colour,
-            self.engine_options.magic_bitboards,
-            &mut self.move_buffer,
-        );
-        order_moves(&mut self.move_buffer[..], game);
+
+        Self::generate_and_order_moves(self, game, colour, 0);
 
         for depth in 1..=self.engine_options.max_depth {
             let mut current_best: Option<ChessMove> = None;
@@ -138,13 +133,7 @@ impl Minimax {
         let depth = self.engine_options.max_depth;
 
         self.move_buffer.clear();
-        MoveGenerator::generate_legal_moves_into(
-            game,
-            colour,
-            self.engine_options.magic_bitboards,
-            &mut self.move_buffer,
-        );
-        order_moves(&mut self.move_buffer, game);
+        Self::generate_and_order_moves(self, game, colour, 0);
 
         while let Some(mv) = self.move_buffer.pop()  {
             game.make_move(&mv);
@@ -186,14 +175,7 @@ impl Minimax {
 
         let move_start_index = self.move_buffer.len();
 
-        // generate moves into buffer for this ply
-        MoveGenerator::generate_legal_moves_into(
-            game,
-            colour,
-            self.engine_options.magic_bitboards,
-            &mut self.move_buffer,
-        );
-        order_moves(&mut self.move_buffer[move_start_index..], game);
+        Self::generate_and_order_moves(self, game, colour, move_start_index);
 
         if let Some(result) = game.is_game_over_with_moves(&self.move_buffer[move_start_index..], self.engine_options.magic_bitboards) {
             self.move_buffer.truncate(move_start_index);
@@ -303,14 +285,8 @@ impl Minimax {
         }
 
         let move_start_index = self.move_buffer.len();
-        // generate only tactical moves into the tactical buffer for this ply
-        MoveGenerator::generate_legal_moves_into(
-            game,
-            to_move,
-            self.engine_options.magic_bitboards,
-            &mut self.move_buffer,
-        );
-        order_moves(&mut self.move_buffer[move_start_index..], game);
+        Self::generate_and_order_moves(self, game, to_move, move_start_index);
+
         if let Some(result) = game.is_game_over_with_moves(&self.move_buffer[move_start_index..], self.engine_options.magic_bitboards) {
             self.move_buffer.truncate(move_start_index);
             return Evaluator::evaluate_game_result(game, Some(result), ply, to_move);
@@ -362,6 +338,17 @@ impl Minimax {
         }
 
         best_score
+    }
+
+    // Helper to generate and order moves starting from a given index in move_buffer
+    fn generate_and_order_moves(&mut self, game: &mut Game, colour: Colour, start_index: usize) {
+        MoveGenerator::generate_legal_moves_into(
+            game,
+            colour,
+            self.engine_options.magic_bitboards,
+            &mut self.move_buffer,
+        );
+        order_moves(&mut self.move_buffer[start_index..], game);
     }
 }
 

--- a/rust_chess/src/engine/minimax.rs
+++ b/rust_chess/src/engine/minimax.rs
@@ -296,12 +296,12 @@ impl Minimax {
             let score = -self.quiescence(game, -beta, -alpha, max_depth - 1, depth_level + 1);
             game.undo_last_move();
 
-            if score >= beta {
-                self.move_buffer.truncate(move_start_index);
-                return score;
-            }
             if score > best_score {
                 best_score = score;
+            }
+            if score >= beta {
+                self.move_buffer.truncate(move_start_index);
+                break;
             }
             if score > alpha {
                 alpha = score;

--- a/rust_chess/src/engine/minimax.rs
+++ b/rust_chess/src/engine/minimax.rs
@@ -93,7 +93,9 @@ impl Minimax {
             let mut current_best_score = -INF;
             let mut current_move_scores: Vec<(ChessMove, i32)> = Vec::new();  // Collect scores for this depth
 
-            // PV move promotion
+            // PV move promotion: Move the previous best move to the end of the buffer.
+            // Since we iterate in reverse (line below), the last element is evaluated first,
+            // so placing the PV move at the end ensures it's searched first for better pruning.
             if let Some(prev_best) = &best_move {
                 if let Some(idx) = self.move_buffer.iter().position(|m| m == prev_best) {
                     let mv = self.move_buffer.swap_remove(idx);

--- a/rust_chess/src/engine/minimax.rs
+++ b/rust_chess/src/engine/minimax.rs
@@ -75,6 +75,7 @@ impl Minimax {
         let out = Evaluator::evaluate_game_result(game, game_result, 0, to_move);
 
         game.undo_last_move();
+        self.move_buffer.truncate(move_start_index);
         out
     }
 

--- a/rust_chess/src/engine/minimax.rs
+++ b/rust_chess/src/engine/minimax.rs
@@ -231,6 +231,7 @@ impl Minimax {
                 best_score = score;
             }
             if best_score >= beta {
+                self.move_buffer.truncate(move_start_index);
                 break;
             }
             if best_score > alpha {

--- a/rust_chess/src/game_classes/game.rs
+++ b/rust_chess/src/game_classes/game.rs
@@ -101,7 +101,7 @@ impl Game {
         
     }
 
-    pub fn is_game_over_with_moves(&mut self, moves: &Vec<ChessMove>, magic_bitboard: bool) -> Option<GameResult> {
+    pub fn is_game_over_with_moves(&mut self, moves: &[ChessMove], magic_bitboard: bool) -> Option<GameResult> {
         let player = self.get_game_state().get_turn();
 
         if self.state_tracker.is_threefold_repetition(self.hash) {

--- a/rust_chess/src/lib.rs
+++ b/rust_chess/src/lib.rs
@@ -78,23 +78,14 @@ impl PyMinimax {
     pub fn go(&mut self) -> String {
         let colour = self.game.get_game_state().get_turn();
         println!("Searching with depth {} (quiescence depth {})...", self.inner.engine_options.max_depth, self.inner.engine_options.quiescence_max_depth);
-        // // println!("Current board eval: {}", self.inner.evaluate(&self.game, colour));
+
         let (best, _) = self.inner.find_best_move(&mut self.game, colour, false);
         return best.unwrap().to_string();
 
-        // let moves = self.inner.find_sorted_moves(&mut self.game, colour);
-        // for (mv, eval) in moves.iter().take(100) {
-        //     println!("{mv}: {eval}");
-        // }
-
-        // return moves[0].0.to_string();
     }
 
     pub fn evaluate_moves(&mut self) -> Vec<(String, i32)> {
         let colour = self.game.get_game_state().get_turn();
-        // // println!("Current board eval: {}", self.inner.evaluate(&self.game, colour));
-        // let best = self.inner.find_best_move(&mut self.game, colour);
-        // return best.unwrap().to_string();
 
         let (_, scores_opt) = self.inner.find_best_move(&mut self.game, colour, true);
         let scores = scores_opt.unwrap();

--- a/rust_chess/src/lib.rs
+++ b/rust_chess/src/lib.rs
@@ -79,7 +79,7 @@ impl PyMinimax {
         let colour = self.game.get_game_state().get_turn();
         println!("Searching with depth {} (quiescence depth {})...", self.inner.engine_options.max_depth, self.inner.engine_options.quiescence_max_depth);
         // // println!("Current board eval: {}", self.inner.evaluate(&self.game, colour));
-        let best = self.inner.find_best_move(&mut self.game, colour);
+        let (best, _) = self.inner.find_best_move(&mut self.game, colour, false);
         return best.unwrap().to_string();
 
         // let moves = self.inner.find_sorted_moves(&mut self.game, colour);
@@ -96,10 +96,9 @@ impl PyMinimax {
         // let best = self.inner.find_best_move(&mut self.game, colour);
         // return best.unwrap().to_string();
 
-        self.inner.find_sorted_moves(&mut self.game, colour)
-            .iter()                          // iterate over & (ChessMove, i32)
-            .map(|(mv, score)| (mv.to_string(), *score))  // convert ChessMove -> String, copy the i32
-            .collect()
+        let (_, scores_opt) = self.inner.find_best_move(&mut self.game, colour, true);
+        let scores = scores_opt.unwrap();
+        scores.into_iter().map(|(mv, score)| (mv.to_string(), score)).collect()
     }
 
     pub fn set_position(&mut self, fenstr: &str, moves: Vec<String>) {
@@ -126,7 +125,7 @@ impl PyMinimax {
     }
 
     pub fn set_quiescence_max_depth(&mut self, quiescence_max_depth: usize) {
-        // self.inner.update_quiescnece_max_depth(quiescence_max_depth);
+        self.inner.engine_options.quiescence_max_depth = quiescence_max_depth;
     }
 
     pub fn set_use_transposition_tables(&mut self, use_tt: bool) {
@@ -150,7 +149,6 @@ impl PyMinimax {
         self.inner.engine_options.use_transposition_tables
     }
 
-    /// Optional: reset the engine TT if you want to start fresh
     pub fn clear_tt(&mut self) {
         self.inner.tt.clear();
     }

--- a/rust_chess/src/lib.rs
+++ b/rust_chess/src/lib.rs
@@ -179,7 +179,7 @@ impl PyMinimax {
         }
     }
 
-    pub fn unmake_move(&mut self, _mv: &str) {
+    pub fn unmake_move(&mut self) {
         self.game.undo_last_move();
     }
 }

--- a/rust_chess/src/lib.rs
+++ b/rust_chess/src/lib.rs
@@ -77,16 +77,16 @@ impl PyMinimax {
 
     pub fn go(&mut self) -> String {
         let colour = self.game.get_game_state().get_turn();
-        // // println!("Current board eval: {}", self.inner.evaluate(&self.game, colour));
-        // let best = self.inner.find_best_move(&mut self.game, colour);
-        // return best.unwrap().to_string();
+        // println!("Current board eval: {}", self.inner.evaluate(&self.game, colour));
+        let best = self.inner.find_best_move(&mut self.game, colour);
+        return best.unwrap().to_string();
 
-        let moves = self.inner.find_sorted_moves(&mut self.game, colour);
-        for (mv, eval) in moves.iter().take(100) {
-            println!("{mv}: {eval}");
-        }
+        // let moves = self.inner.find_sorted_moves(&mut self.game, colour);
+        // for (mv, eval) in moves.iter().take(100) {
+        //     println!("{mv}: {eval}");
+        // }
 
-        return moves[0].0.to_string();
+        // return moves[0].0.to_string();
     }
 
     pub fn evaluate_moves(&mut self) -> Vec<(String, i32)> {

--- a/rust_chess/src/lib.rs
+++ b/rust_chess/src/lib.rs
@@ -77,16 +77,17 @@ impl PyMinimax {
 
     pub fn go(&mut self) -> String {
         let colour = self.game.get_game_state().get_turn();
+        println!("Searching with depth {} (quiescence depth {})...", self.inner.engine_options.max_depth, self.inner.engine_options.quiescence_max_depth);
         // // println!("Current board eval: {}", self.inner.evaluate(&self.game, colour));
-        // let best = self.inner.find_best_move(&mut self.game, colour);
-        // return best.unwrap().to_string();
+        let best = self.inner.find_best_move(&mut self.game, colour);
+        return best.unwrap().to_string();
 
-        let moves = self.inner.find_sorted_moves(&mut self.game, colour);
-        for (mv, eval) in moves.iter().take(100) {
-            println!("{mv}: {eval}");
-        }
+        // let moves = self.inner.find_sorted_moves(&mut self.game, colour);
+        // for (mv, eval) in moves.iter().take(100) {
+        //     println!("{mv}: {eval}");
+        // }
 
-        return moves[0].0.to_string();
+        // return moves[0].0.to_string();
     }
 
     pub fn evaluate_moves(&mut self) -> Vec<(String, i32)> {
@@ -121,7 +122,7 @@ impl PyMinimax {
 
     /// Engine option setters
     pub fn set_max_depth(&mut self, max_depth: usize) {
-        // self.inner.update_max_depth(max_depth);
+        self.inner.engine_options.max_depth = max_depth;
     }
 
     pub fn set_quiescence_max_depth(&mut self, quiescence_max_depth: usize) {
@@ -182,28 +183,6 @@ impl PyMinimax {
 
     pub fn unmake_move(&mut self, _mv: &str) {
         self.game.undo_last_move();
-    }
-
-    pub fn perft(&mut self, depth: u32) -> u64 {
-        if depth == 0 {
-            return 1;
-        }
-
-        let moves = self.generate_legal_moves();
-
-        if depth == 1 {
-            return moves.len() as u64;
-        }
-
-        let mut nodes = 0;
-
-        for mv in moves {
-            self.make_move(&mv);
-            nodes += self.perft(depth - 1);
-            self.unmake_move(&mv);
-        }
-
-        nodes
     }
 }
 

--- a/rust_chess/src/move_ordering.rs
+++ b/rust_chess/src/move_ordering.rs
@@ -23,7 +23,7 @@ fn move_order_score(mv: &ChessMove, game: &Game) -> i32 {
     0
 }
 
-pub fn order_moves(moves: &mut Vec<ChessMove>, game: &Game) {
+pub fn order_moves(moves: &mut [ChessMove], game: &Game) {
     moves.sort_unstable_by_key(|mv| move_order_score(mv, game));
-    moves.reverse(); // highest score first
+    // moves.reverse(); // highest score first
 }

--- a/rust_chess/src/moves/move_generator.rs
+++ b/rust_chess/src/moves/move_generator.rs
@@ -30,8 +30,7 @@ impl MoveGenerator {
         magic_bitboard: bool,
         out_moves: &mut Vec<ChessMove>
     ) {
-        out_moves.clear();
-
+        let initial_len = out_moves.len();
         // generate pseudo-legal moves
         if magic_bitboard {
             Self::generate_pseudo_legal_moves_magic_bitboards_into(game, player, out_moves);
@@ -40,7 +39,7 @@ impl MoveGenerator {
         }
 
         // filter illegal moves in-place
-        let mut i = 0;
+        let mut i = initial_len;
         while i < out_moves.len() {
             if Self::does_leave_player_in_check(game, &out_moves[i], magic_bitboard) {
                 out_moves.swap_remove(i);
@@ -51,36 +50,6 @@ impl MoveGenerator {
 
         // append castling moves
         Self::generate_castling_moves_into(game, player, magic_bitboard, out_moves);
-    }
-
-    pub fn generate_tactical_moves_into(
-        game: &mut Game,
-        to_move: Colour,
-        use_magic: bool,
-        out: &mut Vec<ChessMove>,
-    ) {
-        // Clear the buffer first
-        out.clear();
-
-        // Generate all pseudo-legal moves first
-        let mut pseudo_moves = Vec::new();
-        if use_magic {
-            MoveGenerator::generate_pseudo_legal_moves_magic_bitboards_into(game, to_move, &mut pseudo_moves);
-        } else {
-            MoveGenerator::generate_pseudo_legal_moves_into(game, to_move, &mut pseudo_moves);
-        };
-
-        // Filter tactical moves: captures, promotions, en passant, checks
-        for mv in pseudo_moves {
-            let is_tactical = Self::is_tactical_move(game, &mv, use_magic);
-
-            if is_tactical {
-                // Optionally, skip moves that leave the king in check
-                if !MoveGenerator::does_leave_player_in_check(game, &mv, use_magic) {
-                    out.push(mv);
-                }
-            }
-        }
     }
 
     pub fn is_tactical_move(game: &mut Game, mv: &ChessMove, use_magic: bool) -> bool {
@@ -102,7 +71,6 @@ impl MoveGenerator {
         player: Colour,
         out_moves: &mut Vec<ChessMove>
     ) {
-        out_moves.clear();
         let all_occ = game.get_board().all_occ();
         let own_occ = game.get_board().get_colour_occ(player);
 
@@ -151,7 +119,6 @@ impl MoveGenerator {
         player: Colour,
         out_moves: &mut Vec<ChessMove>
     ) {
-        out_moves.clear();
         for (piece, coords) in &game.get_player_pieces(player) {
             for mv in Self::move_rays_to_chess_moves_into(game, piece, coords) {
                 out_moves.push(mv);

--- a/rust_chess/tests/integration_tests.rs
+++ b/rust_chess/tests/integration_tests.rs
@@ -162,7 +162,7 @@ fn test_iterative_deepening_tt_hits() {
 }
 
 #[test]
-fn test_nodes_per_second_comparison() {
+fn test_nodes_per_second_comparison_tt() {
     let mut engines = vec![
         ("No TT", PyMinimax::new(2, 4, false, false)),
         ("TT", PyMinimax::new(2, 4, true, false)),
@@ -214,8 +214,8 @@ fn test_nodes_per_second_comparison_magic_bitboards() {
 #[test]
 fn test_nodes_per_second_comparison_magic_bitboards_complicated() {
     let mut engines = vec![
-        ("Move Rays", PyMinimax::new(2, 4, false, false)),
-        ("Magic Bitboards", PyMinimax::new(2, 4, false, true)),
+        ("Move Rays", PyMinimax::new(3, 4, true, false)),
+        ("Magic Bitboards", PyMinimax::new(3, 4, true, true)),
     ];
 
 

--- a/rust_chess/tests/perft.rs
+++ b/rust_chess/tests/perft.rs
@@ -1,38 +1,42 @@
 use std::time::Instant;
 use rust_chess::game_classes::game::Game;
 use rust_chess::moves::move_generator::MoveGenerator;
+use rust_chess::enums::ChessMove;
 
 const STARTPOS: &str = "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1";
 const KIWIPETE: &str = "r3k2r/p1ppqpb1/bn2pnp1/3PN3/1p2P3/2N2Q1p/PPPBBPPP/R3K2R w KQkq - 0 1";
 
-fn perft(game: &mut Game, depth: u32, magic_bitboard: bool) -> u64 {
+fn perft(game: &mut Game, depth: u32, magic_bitboard: bool, moves: *mut Vec<Vec<ChessMove>>) -> u64 {
     if depth == 0 {
         return 1;
     }
 
     let colour = game.get_game_state().get_turn();
-    let mut moves = Vec::new();
-    MoveGenerator::generate_legal_moves_into(game, colour, magic_bitboard, &mut moves);
+    let current_moves = unsafe { &mut(&mut (*moves))[depth as usize] };
+    current_moves.clear();
+    MoveGenerator::generate_legal_moves_into(game, colour, magic_bitboard, current_moves);
 
     if depth == 1 {
-        return moves.len() as u64;
+        return current_moves.len() as u64;
     }
 
     let mut count = 0;
-    for mv in &moves {
+    for mv in current_moves {
         game.make_move(mv);
-        count += perft(game, depth - 1, magic_bitboard);
+        count += perft(game, depth - 1, magic_bitboard, moves);
         game.undo_last_move();
     }
     count
 }
 
-fn run_perft_startpos(depth: u32, expected_nodes: u64) {
+fn run_perft_startpos(depth: u32, expected_nodes: u64, magic_bitboard: bool) {
     let mut game = Game::new();
     game.set_fenstr(STARTPOS);
+    let mut moves = vec![Vec::new(); 10];
+    let moves_ptr = &mut moves as *mut Vec<Vec<ChessMove>>;  // Raw pointer to the pool
 
     let start = Instant::now();
-    let nodes = perft(&mut game, depth, true);
+    let nodes = perft(&mut game, depth, magic_bitboard, moves_ptr);
     let duration = start.elapsed();
 
     let nps = nodes as f64 / duration.as_secs_f64();
@@ -43,12 +47,14 @@ fn run_perft_startpos(depth: u32, expected_nodes: u64) {
     assert_eq!(nodes, expected_nodes, "Perft node count mismatch at depth {}", depth);
 }
 
-fn run_perft_kiwipete(depth: u32, expected_nodes: u64) {
+fn run_perft_kiwipete(depth: u32, expected_nodes: u64, magic_bitboard: bool) {
     let mut game = Game::new();
     game.set_fenstr(KIWIPETE);
+    let mut moves = vec![Vec::new(); 10];
+    let moves_ptr = &mut moves as *mut Vec<Vec<ChessMove>>;
 
     let start = Instant::now();
-    let nodes = perft(&mut game, depth, true);
+    let nodes = perft(&mut game, depth, magic_bitboard, moves_ptr);
     let duration = start.elapsed();
 
     let nps = nodes as f64 / duration.as_secs_f64();
@@ -61,64 +67,46 @@ fn run_perft_kiwipete(depth: u32, expected_nodes: u64) {
 
 #[test]
 fn test_perft_startpos_depth1() {
-    run_perft_startpos(1, 20); // Standard perft value for startpos depth 1
+    run_perft_startpos(1, 20, true); // Standard perft value for startpos depth 1
 }
 
 #[test]
 fn test_perft_startpos_depth2() {
-    run_perft_startpos(2, 400); // Standard perft value
+    run_perft_startpos(2, 400, true); // Standard perft value
 }
 
 #[test]
 fn test_perft_startpos_depth3() {
-    run_perft_startpos(3, 8902); // Standard perft value
+    run_perft_startpos(3, 8902, true); // Standard perft value
 }
 
 #[test]
 fn test_perft_startpos_depth4() {
-    run_perft_startpos(4, 197281); // Standard perft value
+    run_perft_startpos(4, 197281, true); // Standard perft value
 }
 
 #[test]
 fn test_perft_kiwipete_depth1() {
-    run_perft_kiwipete(1, 48);
+    run_perft_kiwipete(1, 48, true);
 }
 
 #[test]
 fn test_perft_kiwipete_depth2() {
-    run_perft_kiwipete(2, 2039);
+    run_perft_kiwipete(2, 2039, true);
 }
 
 #[test]
 fn test_perft_kiwipete_depth3() {
-    run_perft_kiwipete(3, 97862);
+    run_perft_kiwipete(3, 97862, true);
 }
 
 #[test]
 fn test_perft_kiwipete_depth4() {
-    run_perft_kiwipete(4, 4085603);
+    run_perft_kiwipete(4, 4085603, true);
 }
 
 #[test]
 fn test_perft_magic_vs_no_magic() {
-    let mut game = Game::new();
-    game.set_fenstr(STARTPOS);
-
-    let start = Instant::now();
-    let nodes = perft(&mut game, 4, true);
-    let duration = start.elapsed();
-
-    let nps = nodes as f64 / duration.as_secs_f64();
-    println!("Magic enabled: {} nodes in {:.3?}, {:.2} nps", nodes, duration, nps);
-    assert_eq!(nodes, 197281); // Standard value
-
-    let mut game_no_magic = Game::new();
-    game_no_magic.set_fenstr(STARTPOS);
-    let start_no_magic = Instant::now();
-    let nodes_no_magic = perft(&mut game_no_magic, 4, false);
-    let duration_no_magic = start_no_magic.elapsed();
-
-    let nps_no_magic = nodes_no_magic as f64 / duration_no_magic.as_secs_f64();
-    println!("Magic disabled: {} nodes in {:.3?}, {:.2} nps", nodes_no_magic, duration_no_magic, nps_no_magic);
-    assert_eq!(nodes_no_magic, 197281); // Standard value
+    run_perft_startpos(4, 197281, true);
+    run_perft_startpos(4, 197281, false);
 }

--- a/rust_chess/tests/perft.rs
+++ b/rust_chess/tests/perft.rs
@@ -1,14 +1,38 @@
 use std::time::Instant;
-use rust_chess::PyMinimax;
+use rust_chess::game_classes::game::Game;
+use rust_chess::moves::move_generator::MoveGenerator;
 
 const STARTPOS: &str = "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1";
+const KIWIPETE: &str = "r3k2r/p1ppqpb1/bn2pnp1/3PN3/1p2P3/2N2Q1p/PPPBBPPP/R3K2R w KQkq - 0 1";
+
+fn perft(game: &mut Game, depth: u32, magic_bitboard: bool) -> u64 {
+    if depth == 0 {
+        return 1;
+    }
+
+    let colour = game.get_game_state().get_turn();
+    let mut moves = Vec::new();
+    MoveGenerator::generate_legal_moves_into(game, colour, magic_bitboard, &mut moves);
+
+    if depth == 1 {
+        return moves.len() as u64;
+    }
+
+    let mut count = 0;
+    for mv in &moves {
+        game.make_move(mv);
+        count += perft(game, depth - 1, magic_bitboard);
+        game.undo_last_move();
+    }
+    count
+}
 
 fn run_perft_startpos(depth: u32, expected_nodes: u64) {
-    let mut engine = PyMinimax::new(0, 4, false, true); // Depth not used, disable TT for pure gen
-    engine.set_position(STARTPOS, vec![]);
+    let mut game = Game::new();
+    game.set_fenstr(STARTPOS);
 
     let start = Instant::now();
-    let nodes = engine.perft(depth);
+    let nodes = perft(&mut game, depth, true);
     let duration = start.elapsed();
 
     let nps = nodes as f64 / duration.as_secs_f64();
@@ -17,6 +41,22 @@ fn run_perft_startpos(depth: u32, expected_nodes: u64) {
         depth, nodes, duration, nps
     );
     assert_eq!(nodes, expected_nodes, "Perft node count mismatch at depth {}", depth);
+}
+
+fn run_perft_kiwipete(depth: u32, expected_nodes: u64) {
+    let mut game = Game::new();
+    game.set_fenstr(KIWIPETE);
+
+    let start = Instant::now();
+    let nodes = perft(&mut game, depth, true);
+    let duration = start.elapsed();
+
+    let nps = nodes as f64 / duration.as_secs_f64();
+    println!(
+        "Kiwipete perft depth {}: {} nodes in {:.3?}, {:.2} nodes/sec",
+        depth, nodes, duration, nps
+    );
+    assert_eq!(nodes, expected_nodes, "Kiwipete perft node count mismatch at depth {}", depth);
 }
 
 #[test]
@@ -40,27 +80,45 @@ fn test_perft_startpos_depth4() {
 }
 
 #[test]
+fn test_perft_kiwipete_depth1() {
+    run_perft_kiwipete(1, 48);
+}
+
+#[test]
+fn test_perft_kiwipete_depth2() {
+    run_perft_kiwipete(2, 2039);
+}
+
+#[test]
+fn test_perft_kiwipete_depth3() {
+    run_perft_kiwipete(3, 97862);
+}
+
+#[test]
+fn test_perft_kiwipete_depth4() {
+    run_perft_kiwipete(4, 4085603);
+}
+
+#[test]
 fn test_perft_magic_vs_no_magic() {
-    let mut no_magic = PyMinimax::new(0, 4, false, false);
-    let mut magic = PyMinimax::new(0, 4, false, true);
-
-    no_magic.set_position(STARTPOS, vec![]);
-    magic.set_position(STARTPOS, vec![]);
+    let mut game = Game::new();
+    game.set_fenstr(STARTPOS);
 
     let start = Instant::now();
-    let nodes_no_magic = no_magic.perft(4);
-    let duration_no_magic = start.elapsed();
+    let nodes = perft(&mut game, 4, true);
+    let duration = start.elapsed();
 
-    let start = Instant::now();
-    let nodes_magic = magic.perft(4);
-    let duration_magic = start.elapsed();
+    let nps = nodes as f64 / duration.as_secs_f64();
+    println!("Magic enabled: {} nodes in {:.3?}, {:.2} nps", nodes, duration, nps);
+    assert_eq!(nodes, 197281); // Standard value
+
+    let mut game_no_magic = Game::new();
+    game_no_magic.set_fenstr(STARTPOS);
+    let start_no_magic = Instant::now();
+    let nodes_no_magic = perft(&mut game_no_magic, 4, false);
+    let duration_no_magic = start_no_magic.elapsed();
 
     let nps_no_magic = nodes_no_magic as f64 / duration_no_magic.as_secs_f64();
-    let nps_magic = nodes_magic as f64 / duration_magic.as_secs_f64();
-
-    println!("No Magic: {} nodes in {:.3?}, {:.2} nps", nodes_no_magic, duration_no_magic, nps_no_magic);
-    println!("Magic: {} nodes in {:.3?}, {:.2} nps", nodes_magic, duration_magic, nps_magic);
-
-    assert_eq!(nodes_no_magic, nodes_magic); // Should be same node count
-    // Performance comparison is printed for manual inspection; timing-based assertions are unreliable in CI.
+    println!("Magic disabled: {} nodes in {:.3?}, {:.2} nps", nodes_no_magic, duration_no_magic, nps_no_magic);
+    assert_eq!(nodes_no_magic, 197281); // Standard value
 }

--- a/rust_chess/tests/perft.rs
+++ b/rust_chess/tests/perft.rs
@@ -6,37 +6,40 @@ use rust_chess::enums::ChessMove;
 const STARTPOS: &str = "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1";
 const KIWIPETE: &str = "r3k2r/p1ppqpb1/bn2pnp1/3PN3/1p2P3/2N2Q1p/PPPBBPPP/R3K2R w KQkq - 0 1";
 
-fn perft(game: &mut Game, depth: u32, magic_bitboard: bool, moves: *mut Vec<Vec<ChessMove>>) -> u64 {
+fn perft(game: &mut Game, depth: u32, magic_bitboard: bool, moves: &mut Vec<ChessMove>) -> u64 {
     if depth == 0 {
         return 1;
     }
 
     let colour = game.get_game_state().get_turn();
-    let current_moves = unsafe { &mut(&mut (*moves))[depth as usize] };
-    current_moves.clear();
-    MoveGenerator::generate_legal_moves_into(game, colour, magic_bitboard, current_moves);
+    let start_moves_len = moves.len();
+    MoveGenerator::generate_legal_moves_into(game, colour, magic_bitboard, moves);
 
     if depth == 1 {
-        return current_moves.len() as u64;
+        let out = moves.len() as u64 - start_moves_len as u64;
+        moves.truncate(start_moves_len);
+        return out;
     }
 
     let mut count = 0;
-    for mv in current_moves {
-        game.make_move(mv);
+
+    while moves.len() > start_moves_len {
+        let mv = moves.pop().unwrap();
+        game.make_move(&mv);
         count += perft(game, depth - 1, magic_bitboard, moves);
         game.undo_last_move();
     }
+
     count
 }
 
 fn run_perft_startpos(depth: u32, expected_nodes: u64, magic_bitboard: bool) {
     let mut game = Game::new();
     game.set_fenstr(STARTPOS);
-    let mut moves = vec![Vec::new(); 10];
-    let moves_ptr = &mut moves as *mut Vec<Vec<ChessMove>>;  // Raw pointer to the pool
+    let mut moves = Vec::with_capacity(2048);
 
     let start = Instant::now();
-    let nodes = perft(&mut game, depth, magic_bitboard, moves_ptr);
+    let nodes = perft(&mut game, depth, magic_bitboard, &mut moves);
     let duration = start.elapsed();
 
     let nps = nodes as f64 / duration.as_secs_f64();
@@ -50,11 +53,10 @@ fn run_perft_startpos(depth: u32, expected_nodes: u64, magic_bitboard: bool) {
 fn run_perft_kiwipete(depth: u32, expected_nodes: u64, magic_bitboard: bool) {
     let mut game = Game::new();
     game.set_fenstr(KIWIPETE);
-    let mut moves = vec![Vec::new(); 10];
-    let moves_ptr = &mut moves as *mut Vec<Vec<ChessMove>>;
+    let mut moves = Vec::with_capacity(2048);
 
     let start = Instant::now();
-    let nodes = perft(&mut game, depth, magic_bitboard, moves_ptr);
+    let nodes = perft(&mut game, depth, magic_bitboard, &mut moves);
     let duration = start.elapsed();
 
     let nps = nodes as f64 / duration.as_secs_f64();


### PR DESCRIPTION
Key changes:
- Adds the Kiwipete position to run perft tests on
- Perft tests now generate moves similar to in minimax
- Refactor minimax to use a single move buffer (see #36)
- Clean up minimax.rs
